### PR TITLE
fix for #75

### DIFF
--- a/flagsmith-core.js
+++ b/flagsmith-core.js
@@ -254,6 +254,7 @@ const Flagsmith = class {
                 this.getFlags(resolve, reject);
             }
         })
+        .catch(error => onError(error));
     }
 
     getAllFlags() {


### PR DESCRIPTION
Throwing exception in the Flagsmith.init (https://github.com/Flagsmith/flagsmith-js-client/blob/master/flagsmith-core.js#L181) function causes onError handler not fired. Adding .catch block for init function solves the problem.