### PR TITLE
Prevent GET request to inject header "content-type"

### DIFF
--- a/flagsmith-core.js
+++ b/flagsmith-core.js
@@ -29,7 +29,7 @@ const Flagsmith = class {
                 'x-environment-key': environmentID
             }
         };
-        if (method !== "GET")
+        if (method && method !== "GET")
             options.headers['Content-Type'] = 'application/json; charset=utf-8'
         return fetch(url, options)
             .then(res => {


### PR DESCRIPTION
Prevent GET request to inject header "content-type", it's not working, it's always set the "content-type" header, because when it's a GET method the variable method it's undefined and the condition is never true.