### PR TITLE
Change type of value

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 export interface IBulletTrainFeature {
     enabled: boolean
-    value?: string
+    value?: string|number|boolean
 }
 
 export interface IFlags {


### PR DESCRIPTION
We stumbled onto some typing errors with the IBulletTrainFeature when using `getValue()` because this latter is `string|number|boolean`. This tries to fix this.