### PR TITLE
Remove bullet train references

### DIFF
--- a/examples/angular/package-lock.json
+++ b/examples/angular/package-lock.json
@@ -3107,9 +3107,6 @@
       "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true
     },
-    "bullet-train-client": {
-      "version": "file:../../bullet-train-client"
-    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -5045,6 +5042,9 @@
       "requires": {
         "locate-path": "^3.0.0"
       }
+    },
+    "flagsmith": {
+      "version": "file:../../flagsmith"
     },
     "flatted": {
       "version": "2.0.1",

--- a/examples/deno/README.md
+++ b/examples/deno/README.md
@@ -1,6 +1,6 @@
 <img width="100%" src="https://raw.githubusercontent.com/Flagsmith/flagsmith/main/static-files/hero.png"/>
 
-# Bullet Train Feature Flags with Deno
+# Flagsmith Flags with Deno
 
 This repository contains basic integration with Deno.
 
@@ -17,13 +17,13 @@ mode with nodemon reloading npm install.
 
 ```bash
 npm i
-BULLET_TRAIN="YOUR_ENV" npm run dev
+FLAGSMITH="YOUR_ENV" npm run dev
 ```
 
 ## Bundling and running
 
 ```bash
-BULLET_TRAIN="YOUR_ENV" npm start
+FLAGSMITH="YOUR_ENV" npm start
 ```
 
 Goto http://localhost:8000.

--- a/examples/deno/app/flagsmith.ts
+++ b/examples/deno/app/flagsmith.ts
@@ -5,8 +5,8 @@ const flagsmith = Flagsmith({fetch, AsyncStorage: null});
 export default flagsmith;
 export const init  = async function (){
     return await flagsmith.init({
-        environmentID: Deno.env("BULLET_TRAIN"),
-        api: "https://api.bullet-train.io/api/v1/",
+        environmentID: Deno.env("FLAGSMITH"),
+        api: "https://api.flagsmith.com/api/v1/",
         onError: (err) => {},
         onChange: (err) => {},
         cacheFlags: false,

--- a/examples/deno/app/index.ts
+++ b/examples/deno/app/index.ts
@@ -1,5 +1,5 @@
 import {Application, Router} from "https://deno.land/x/oak/mod.ts";
-import {init} from './bullet-train.ts';
+import {init} from './flagsmith.ts';
 import router from './router.ts';
 
 const start = async ()=> {
@@ -11,3 +11,4 @@ const start = async ()=> {
 };
 
 start();
+``

--- a/examples/deno/app/router.ts
+++ b/examples/deno/app/router.ts
@@ -1,5 +1,5 @@
 import {Router} from "https://deno.land/x/oak/mod.ts";
-import flagsmith from './bullet-train.ts';
+import flagsmith from './flagsmith.ts';
 
 const router = new Router();
 router

--- a/examples/deno/package.json
+++ b/examples/deno/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deno-example",
   "version": "1.0.0",
-  "description": "Using Bullet Train with Deno",
+  "description": "Using Flagsmith with Deno",
   "scripts": {
     "build": "deno bundle ./app/index.ts ./out.ts",
     "dev": "nodemon --exec deno --allow-net --allow-env ./app/index.ts",

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -1,4 +1,4 @@
-<img width="100%" src="https://raw.githubusercontent.com/SolidStateGroup/bullet-train-frontend/master/hero.png"/>
+<img width="100%" src="https://github.com/Flagsmith/flagsmith/raw/main/static-files/hero.png"/>
 
 ## Flagsmith with React Native
 This repository contains basic integration with a standard react-native init application.

--- a/examples/react/README.md
+++ b/examples/react/README.md
@@ -1,4 +1,4 @@
-<img width="100%" src="https://raw.githubusercontent.com/SolidStateGroup/bullet-train-frontend/master/hero.png"/>
+<img width="100%" src="https://github.com/Flagsmith/flagsmith/raw/main/static-files/hero.png"/>
 
 # Flagsmith with React
 

--- a/flagsmith/index.d.ts
+++ b/flagsmith/index.d.ts
@@ -1,10 +1,13 @@
+// Deprecated
 export interface IBulletTrainFeature {
     enabled: boolean
-    value?: string
+    value?: string|number|boolean
 }
 
+export interface IFlagsmithFeature extends IBulletTrainFeature {}
+
 export interface IFlags {
-    [key: string]: IBulletTrainFeature
+    [key: string]: IFlagsmithFeature
 }
 
 export interface ITraits {
@@ -12,7 +15,7 @@ export interface ITraits {
 }
 
 export interface IUserIdentity {
-    flags: IBulletTrainFeature
+    flags: IFlagsmithFeature
     traits: ITraits
 }
 export interface IRetrieveInfo {
@@ -33,8 +36,9 @@ declare class IFlagsmith {
      * Initialise the sdk against a particular environment
      */
     init:(config: {
-        environmentID: string // your Bullet Train environment id
+        environmentID: string // your Flagsmith environment id
         api?: string // the api you wish to use, important if self hosting
+        headers?: object // pass custom headers for flagsmith api calls
         AsyncStorage?: any // an AsyncStorage implementation
         cacheFlags?: boolean // whether to local storage flags, needs AsyncStorage defined
         preventFetch?: boolean // whether to prevent fetching flags on init

--- a/flagsmith/package.json
+++ b/flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,13 @@
+// Deprecated
 export interface IBulletTrainFeature {
     enabled: boolean
     value?: string|number|boolean
 }
 
+export interface IFlagsmithFeature extends IBulletTrainFeature {}
+
 export interface IFlags {
-    [key: string]: IBulletTrainFeature
+    [key: string]: IFlagsmithFeature
 }
 
 export interface ITraits {
@@ -12,7 +15,7 @@ export interface ITraits {
 }
 
 export interface IUserIdentity {
-    flags: IBulletTrainFeature
+    flags: IFlagsmithFeature
     traits: ITraits
 }
 export interface IRetrieveInfo {
@@ -33,7 +36,7 @@ declare class IFlagsmith {
      * Initialise the sdk against a particular environment
      */
     init:(config: {
-        environmentID: string // your Bullet Train environment id
+        environmentID: string // your Flagsmith environment id
         api?: string // the api you wish to use, important if self hosting
         headers?: object // pass custom headers for flagsmith api calls
         AsyncStorage?: any // an AsyncStorage implementation
@@ -50,7 +53,7 @@ declare class IFlagsmith {
     /**
      * Trigger a manual fetch of the environment features
      */
-    getFlags:()=> Promise<IFlags>
+    getFlags:()=> Promise<null>
 
     /**
      * Returns the current flags
@@ -70,7 +73,7 @@ declare class IFlagsmith {
     /**
      * Clears the identity, triggers a call to getFlags
      */
-    logout:()=> Promise<IFlags>
+    logout:()=> Promise<null>
 
     /**
      * Polls the flagsmith API, specify interval in ms
@@ -103,14 +106,14 @@ declare class IFlagsmith {
     setTrait:(
         key: string,
         value: string|number|boolean
-    )=> Promise<IFlags>
+    )=> Promise<null>
 
     /**
      * Set a key value set of traits for a given user, triggers a call to get flags
      */
     setTraits:(
         traits: Record<string, string|number|boolean>,
-    )=> Promise<IFlags>
+    )=> Promise<null>
 
     /**
      * Increments the value of a numeric trait by a given amount (can be negative number)
@@ -118,7 +121,7 @@ declare class IFlagsmith {
     incrementTrait:(
         key:string,
         incrementBy:number
-    )=> Promise<IFlags>
+    )=> Promise<null>
 
     /**
      * The stored identity of the user

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/SolidStateGroup/bullet-train-js-client"
+    "url": "https://github.com/Flagsmith/flagsmith-js-client/"
   },
   "keywords": [
     "react native",
@@ -20,9 +20,9 @@
   "author": "SSG",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/SolidStateGroup/bullet-train-js-client/issues"
+    "url": "https://github.com/Flagsmith/flagsmith-js-client//issues"
   },
-  "homepage": "https://bullet-train.io",
+  "homepage": "https://flagsmith.com",
   "devDependencies": {
     "@babel/cli": "^7.13.14",
     "@babel/core": "^7.6.4",

--- a/react-native-flagsmith/README.md
+++ b/react-native-flagsmith/README.md
@@ -1,13 +1,13 @@
-<img width="100%" src="https://raw.githubusercontent.com/SolidStateGroup/bullet-train-frontend/master/hero.png"/>
+<img width="100%" src="https://github.com/Flagsmith/flagsmith/raw/main/static-files/hero.png"/>
 
 # Flagsmith Client
 [![npm version](https://badge.fury.io/js/flagsmith.svg)](https://badge.fury.io/js/flagsmith)
 [![](https://data.jsdelivr.com/v1/package/npm/flagsmith/badge)](https://www.jsdelivr.com/package/npm/flagsmith)
 
-The SDK clients for web and React Native for [https://bullet-train.io/](https://www.bullet-train.io/). Flagsmith allows you to manage feature flags and remote config across multiple projects, environments and organisations.
+The SDK clients for web and React Native for [https://flagsmith.com/](https://flagsmith.com/). Flagsmith allows you to manage feature flags and remote config across multiple projects, environments and organisations.
 
 ## Getting Started
-**For full documentation visit [https://docs.bullet-train.io/clients/javascript/](https://docs.bullet-train.io/clients/javascript/)**
+**For full documentation visit [https://docs.flagsmith.com/clients/javascript/](https://docs.flagsmith.com/clients/javascript/)**
 
 These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See running in production for notes on how to deploy the project on a live system.
 

--- a/react-native-flagsmith/index.d.ts
+++ b/react-native-flagsmith/index.d.ts
@@ -1,10 +1,13 @@
+// Deprecated
 export interface IBulletTrainFeature {
     enabled: boolean
     value?: string|number|boolean
 }
 
+export interface IFlagsmithFeature extends IBulletTrainFeature {}
+
 export interface IFlags {
-    [key: string]: IBulletTrainFeature
+    [key: string]: IFlagsmithFeature
 }
 
 export interface ITraits {
@@ -12,7 +15,7 @@ export interface ITraits {
 }
 
 export interface IUserIdentity {
-    flags: IBulletTrainFeature
+    flags: IFlagsmithFeature
     traits: ITraits
 }
 export interface IRetrieveInfo {
@@ -33,7 +36,7 @@ declare class IFlagsmith {
      * Initialise the sdk against a particular environment
      */
     init:(config: {
-        environmentID: string // your Bullet Train environment id
+        environmentID: string // your Flagsmith environment id
         api?: string // the api you wish to use, important if self hosting
         AsyncStorage?: any // an AsyncStorage implementation
         cacheFlags?: boolean // whether to local storage flags, needs AsyncStorage defined

--- a/react-native-flagsmith/package.json
+++ b/react-native-flagsmith/package.json
@@ -1,11 +1,11 @@
 {
   "name": "react-native-flagsmith",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Feature flagging to support continuous development",
   "main": "./lib/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/SolidStateGroup/bullet-train-js-client"
+    "url": "https://github.com/Flagsmith/flagsmith-js-client/"
   },
   "keywords": [
     "react native",
@@ -15,9 +15,9 @@
   "author": "SSG",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/SolidStateGroup/bullet-train-js-client/issues"
+    "url": "https://github.com/Flagsmith/flagsmith-js-client/issues"
   },
-  "homepage": "https://bullet-train.io",
+  "homepage": "https://flagsmith.com",
   "peerDependencies": {
     "react-native": ">=0.20.0"
   },


### PR DESCRIPTION
"BULLET_TRAIN_DB" and "BULLET_TRAIN_EVENT" are keys for local storage so will remain for now, rolling a major version for vanity

IBulletTrainFeature has been deprecated but will have to remain to allow for a non-breaking version due to people likely importing it.