### PR TITLE
fix: guard against null `onError` in init

### DIFF
--- a/flagsmith-core.js
+++ b/flagsmith-core.js
@@ -276,7 +276,7 @@ const Flagsmith = class {
                 resolve();
             }
         })
-        .catch(error => onError(error));
+        .catch(error => onError && onError(error));
     }
 
     getAllFlags() {


### PR DESCRIPTION
fixes #97