### PR TITLE
Fix error being thrown on init

### DIFF
--- a/flagsmith-core.js
+++ b/flagsmith-core.js
@@ -244,7 +244,7 @@ const Flagsmith = class {
                                 this.oldFlags = this.flags;
                                 resolve();
                                 if (!preventFetch) {
-                                    this.getFlags(Promise.resolve, Promise.reject);
+                                    this.getFlags();
                                 }
                             } else {
                                 if (!preventFetch) {


### PR DESCRIPTION
I'm initiating `flagsmith` in the following way:

```javascript
flagsmith
  .init({
    environmentID: flagsmithEnvironmentId,
    onChange: (e) => { console.log('onChange', e) },
    onError: (e) => { console.log('onError', e) },
    cacheFlags: true,
    enableAnalytics: true,
    enableLogs: false,
    AsyncStorage,
  })
  .catch((e) => { console.log('catch', e) })
```

`flagsmith` is initiated correctly, but `onError` catches an error immediately after initiating: `Uncaught TypeError: PromiseResolve called on non-object`.

Apparently this error arises because somewhere in the code it's passing a `Promise.resolve` as arg to another function, which then calls it. If you want to reproduce it minimally, please run this code below in any JavaScript engine:

```javascript
const f = (g) => g(); f(Promise.resolve);
```

Glancing over the code I think that just avoiding passing `Promise.resolve` and `Promise.reject` as args is enough to avoid this error.