### PR TITLE
Default traits to empty array in useFlags

### DIFF
--- a/react/index.tsx
+++ b/react/index.tsx
@@ -84,7 +84,7 @@ const getRenderKey = (flagsmith: IFlagsmith, flags: string[], traits: string[] =
         .join(',')
 }
 
-export function useFlags<F extends string, T extends string>(_flags: readonly F[], _traits?: readonly T[]): {
+export function useFlags<F extends string, T extends string>(_flags: readonly F[], _traits: readonly T[] = []): {
     [K in F]: IFlagsmithFeature
 } & {
     [K in T]: IFlagsmithTrait


### PR DESCRIPTION
The typescript definitions for the `useFlags` mark the traits array as optional. However, if you omit the array when using the hook, you'll be faced with the following warning which comes from the `flagsAsArray` function.

> 'Flagsmith: please supply an array of strings or a single string of flag keys to useFlags'

Changing the traits to default to an empty array in the function signature would remove the error and still keep the types the same. We just have to change `?:` to `:` otherwise TS will complain that you can't have a `?` and a default value.