### PR TITLE
Do not depend on listener to run getFlags

### DIFF
--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -313,7 +313,7 @@ const Flagsmith = class {
         if(traits) {
             this.withTraits = traits;
         }
-        if (this.initialised && !this.getFlagInterval) {
+        if (this.initialised) {
             return this.getFlags();
         }
         return Promise.resolve();
@@ -370,7 +370,7 @@ const Flagsmith = class {
         this.identity = null;
         this.segments = null;
         this.traits = null;
-        if (this.initialised && !this.getFlagInterval) {
+        if (this.initialised) {
             return this.getFlags();
         }
         return Promise.resolve();


### PR DESCRIPTION
This PR is a proposal to fix issue https://github.com/Flagsmith/flagsmith-js-client/issues/103. The idea is to just not condition on `getFlagInterval` when deciding whether to run `getFlags` after a call to `identify` or `logout`.