### PR TITLE
incrementTrait throws an error

### DIFF
--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -506,8 +506,7 @@ const Flagsmith = class {
             increment_by,
             identifier: identity
         }))
-            // @ts-ignore
-            .then(this.getFlags)
+            .then(() => this.getFlags())
     };
 
     hasFeature = (key) => {


### PR DESCRIPTION
This only shows up if you have onError set log out errors.  the message that comes back: `TypeError: t is not a function`