### PR TITLE
Fix types for React 18

### DIFF
--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -5,6 +5,7 @@ export declare type FlagsmithContextType = {
     flagsmith: IFlagsmith;
     serverState?: IState;
     options: Parameters<IFlagsmith['init']>[0];
+    children: React.ReactElement[] | React.ReactElement;
 };
 export declare const FlagsmithProvider: FC<FlagsmithContextType>;
 export declare function useFlags<F extends string, T extends string>(_flags: readonly F[], _traits?: readonly T[]): {


### PR DESCRIPTION
This seems to fix #115 for me locally, and should have no breaking changes for React 17