### PR TITLE
Update provider children types in other files

### DIFF
--- a/flagsmith-es/react/index.d.ts
+++ b/flagsmith-es/react/index.d.ts
@@ -5,6 +5,7 @@ export declare type FlagsmithContextType = {
     flagsmith: IFlagsmith;
     options?: Parameters<IFlagsmith['init']>[0];
     serverState?: IState;
+    children: React.ReactElement[] | React.ReactElement;
 };
 export declare const FlagsmithProvider: FC<FlagsmithContextType>;
 export declare function useFlags<F extends string, T extends string>(_flags: readonly F[], _traits?: readonly T[]): {

--- a/flagsmith/react/index.d.ts
+++ b/flagsmith/react/index.d.ts
@@ -5,6 +5,7 @@ export declare type FlagsmithContextType = {
     flagsmith: IFlagsmith;
     options?: Parameters<IFlagsmith['init']>[0];
     serverState?: IState;
+    children: React.ReactElement[] | React.ReactElement;
 };
 export declare const FlagsmithProvider: FC<FlagsmithContextType>;
 export declare function useFlags<F extends string, T extends string>(_flags: readonly F[], _traits?: readonly T[]): {

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -21,6 +21,7 @@ export type FlagsmithContextType = {
     flagsmith: IFlagsmith // The flagsmith instance
     options?: Parameters<IFlagsmith['init']>[0] // Initialisation options, if you do not provide this you will have to call init manually
     serverState?: IState
+    children: React.ReactElement[] | React.ReactElement;
 }
 
 export const FlagsmithProvider: FC<FlagsmithContextType> = ({


### PR DESCRIPTION
In #116 I did not realize these types are re-defined in a few other places. While that came as a bit of a surprise, here is a fix to just get things correctly typed everywhere. 

A longer-term solution would obviously not to define the same types more than once.