### PR TITLE
chore: use T generic for identify function

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -119,7 +119,7 @@ export interface IFlagsmith<F extends string = string, T extends string = string
     /**
      * Identify user, triggers a call to get flags if flagsmith.init has been called
      */
-    identify: (userId: string, traits?: Record<string, IFlagsmithValue>) => Promise<void>;
+    identify: (userId: string, traits?: Record<T, IFlagsmithValue>) => Promise<void>;
     /**
      * Retrieves the current state of flagsmith
      */


### PR DESCRIPTION
This a very small update, but the goal is to leverage the `T` generic referring to the trait type while using the `identify` function.

This allows better checks and completion when calling the `identify` function when setting custom types for Traits and Flags.