### PR TITLE
fix: Return cache on api error

### DIFF
--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -368,19 +368,22 @@ const Flagsmith = class {
             }
 
             this._trigger = _trigger || this._trigger;
-            this.onError = onError? (message:any)=> {
+            this.onError = (message:any)=> {
                 this.setLoadingState({
                     ...this.loadingState,
                     isFetching: false,
                     isLoading: false,
                     error: message
                 })
-                if (message instanceof Error) {
-                    onError(message)
-                } else {
-                    onError(new Error(message))
+                if (onError) {
+                    if (message instanceof Error) {
+                        onError(message)
+                    } else {
+                        onError(new Error(message))
+                    }    
                 }
-            }: null
+            }
+
             this.identity = identity;
             this.withTraits = traits;
             this.enableLogs = enableLogs|| false;

--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -1,5 +1,4 @@
 import {
-    FlagSource,
     GetValueOptions,
     IDatadogRum,
     IFlags,
@@ -220,7 +219,7 @@ const Flagsmith = class {
                     isFromServer: true,
                     flagsChanged: !flagsEqual,
                     traitsChanged: !traitsEqual
-                }, this._loadedState(FlagSource.SERVER));
+                }, this._loadedState(null, FlagSource.SERVER));
             }
         };
 
@@ -596,7 +595,7 @@ const Flagsmith = class {
                                     const shouldFetchFlags = !preventFetch && (!this.cacheOptions.skipAPI||!cachePopulated)
                                     this.onChange?.(null,
                                         { isFromServer: false, flagsChanged: true, traitsChanged: !!this.traits },
-                                         this._loadedState(FlagSource.CACHE, shouldFetchFlags)
+                                         this._loadedState(null, FlagSource.CACHE, shouldFetchFlags)
                                     );
                                     this.oldFlags = this.flags;
                                     resolve(true);
@@ -623,12 +622,12 @@ const Flagsmith = class {
                                 if (defaultFlags) {
                                     this.onChange?.(null,
                                         { isFromServer: false, flagsChanged: true, traitsChanged: !!this.traits },
-                                        this._loadedState(FlagSource.DEFAULT_FLAGS)
+                                        this._loadedState(null, FlagSource.DEFAULT_FLAGS)
                                     );
                                 } else if (this.flags) { // flags exist due to set state being called e.g. from nextJS serverState
                                     this.onChange?.(null,
                                         { isFromServer: false, flagsChanged: true, traitsChanged: !!this.traits },
-                                        this._loadedState(FlagSource.DEFAULT_FLAGS)
+                                        this._loadedState(null, FlagSource.DEFAULT_FLAGS)
                                     );
                                 } else {
                                     onError(WRONG_FLAGSMITH_CONFIG);
@@ -643,7 +642,7 @@ const Flagsmith = class {
                 this.getFlags(resolve, reject);
             } else {
                 if (defaultFlags) {
-                    this.onChange?.(null, { isFromServer: false, flagsChanged: true, traitsChanged:!!this.traits },this._loadedState(FlagSource.CACHE));
+                    this.onChange?.(null, { isFromServer: false, flagsChanged: true, traitsChanged:!!this.traits },this._loadedState(null, FlagSource.CACHE));
                 }else if (this.flags) {
                     let error = null
                     if(Object.keys(this.flags).length === 0){

--- a/react.tsx
+++ b/react.tsx
@@ -144,17 +144,18 @@ export function useFlags<F extends string=string, T extends string=string>(_flag
         }
     },[renderRef])
 
+    events.once('event', eventListener)
+    
     if (firstRender.current) {
         firstRender.current = false;
         flagsmith?.log("React - Initialising event listeners")
     }
 
     useEffect(()=>{
-        events.on('event', eventListener)
         return () => {
             events.off('event', eventListener)
         }
-    }, [eventListener])
+    }, [])
 
     const res = useMemo(() => {
         const res: any = {}


### PR DESCRIPTION
Cached data was not being returned when cacheFlags was enabled and API calls failed.

Solved by getting the event subscription on useFlags out of the useEffect.

Also, creating a default onError function to set the loadingState value to the apporpiate values in case of error.
