### PR TITLE
fix: Set BSD-3 Clause as license type in package.json

### DIFF
--- a/lib/flagsmith-es/package-lock.json
+++ b/lib/flagsmith-es/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "flagsmith-es",
       "version": "3.18.4",
-      "license": "MIT"
+      "license": "BSD-3-Clause"
     }
   }
 }

--- a/lib/flagsmith-es/package.json
+++ b/lib/flagsmith-es/package.json
@@ -13,7 +13,7 @@
     "continuous deployment"
   ],
   "author": "Flagsmith Ltd",
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/Flagsmith/flagsmith-js-client/issues"
   },

--- a/lib/flagsmith/package-lock.json
+++ b/lib/flagsmith/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "flagsmith",
       "version": "3.18.4",
-      "license": "MIT"
+      "license": "BSD-3-Clause"
     }
   }
 }

--- a/lib/flagsmith/package.json
+++ b/lib/flagsmith/package.json
@@ -12,7 +12,7 @@
     "continuous deployment"
   ],
   "author": "Flagsmith Ltd",
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/Flagsmith/flagsmith-js-client/issues"
   },

--- a/lib/react-native-flagsmith/package-lock.json
+++ b/lib/react-native-flagsmith/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "react-native-flagsmith",
       "version": "3.20.0",
-      "license": "MIT",
+      "license": "BSD-3-Clause",
       "peerDependencies": {
         "react-native": ">=0.20.0"
       }

--- a/lib/react-native-flagsmith/package.json
+++ b/lib/react-native-flagsmith/package.json
@@ -13,7 +13,7 @@
     "continuous deployment"
   ],
   "author": "SSG",
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/Flagsmith/flagsmith-js-client/issues"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "flagsmith",
       "hasInstallScript": true,
-      "license": "MIT",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@callstack/async-storage": "1.1.0",
         "encoding": "^0.1.12",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "continuous deployment"
   ],
   "author": "SSG",
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/Flagsmith/flagsmith-js-client/issues"
   },


### PR DESCRIPTION
Currently, there is an inconsistency in the package licence between GitHub and NPM. The packages' license in NPM should be BSD-3 as in GitHub.