### PR TITLE
Respect `fallback` also without `json` flag in `getValue`

### DIFF
--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -826,7 +826,7 @@ const Flagsmith = class {
             try {
                 if (res === null) {
                     this.log("Tried to parse null flag as JSON: " + key);
-                    return undefined;
+                    return null;
                 }
                 return JSON.parse(res as string);
             } catch (e) {

--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -818,15 +818,19 @@ const Flagsmith = class {
             this.evaluateFlag(key, "VALUE");
         }
 
+        if (res === null && typeof options?.fallback !== 'undefined') {
+            return options.fallback;
+        }
+
         if (options?.json) {
             try {
                 if (res === null) {
-                    this.log("Tried to parse null flag as JSON: " + key)
-                    return options.fallback;
+                    this.log("Tried to parse null flag as JSON: " + key);
+                    return undefined;
                 }
-                return JSON.parse(res as string)
+                return JSON.parse(res as string);
             } catch (e) {
-                return options.fallback
+                return options.fallback;
             }
         }
         //todo record check for value

--- a/lib/flagsmith-es/package.json
+++ b/lib/flagsmith-es/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith-es",
-  "version": "3.22.0",
+  "version": "3.22.1",
   "description": "Feature flagging to support continuous development. This is an esm equivalent of the standard flagsmith npm module.",
   "main": "./index.js",
   "type": "module",

--- a/lib/flagsmith/package.json
+++ b/lib/flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith",
-  "version": "3.22.0",
+  "version": "3.22.1",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {

--- a/lib/react-native-flagsmith/package.json
+++ b/lib/react-native-flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flagsmith",
-  "version": "3.22.0",
+  "version": "3.22.1",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {


### PR DESCRIPTION
Allows the following usage:

```ts
flagsmith.getValue('refresh_interval', { fallback: 10000 });
```

Fixes #212