### PR TITLE
Add no-cache option

### DIFF
--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -81,6 +81,8 @@ const Flagsmith = class {
         const options: RequestOptions = {
             method: method || 'GET',
             body,
+            // @ts-ignore next-js overrides fetch
+            cache: 'no-cache',
             headers: {
                 'x-environment-key': `${environmentID}`
             }

--- a/lib/flagsmith-es/package.json
+++ b/lib/flagsmith-es/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith-es",
-  "version": "3.23.0",
+  "version": "3.23.1",
   "description": "Feature flagging to support continuous development. This is an esm equivalent of the standard flagsmith npm module.",
   "main": "./index.js",
   "type": "module",

--- a/lib/flagsmith/package.json
+++ b/lib/flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith",
-  "version": "3.23.0",
+  "version": "3.23.1",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {

--- a/lib/react-native-flagsmith/package.json
+++ b/lib/react-native-flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flagsmith",
-  "version": "3.23.0",
+  "version": "3.23.1",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {


### PR DESCRIPTION
 Nextjs is polyfilling fetch to always use cache regardless of freshness. https://nextjs.org/docs/app/building-your-application/caching#fetch

The browser looks for a matching request in its HTTP cache. If there is a match, fresh or stale, it will be returned from the cache. If there is no match, the browser will make a normal request, and will update the cache with the downloaded resource.

We'd always want cache off as it's handled at the local storage level, this PR turns that feature off.