### PR TITLE
chore: add withTraits when setting state

### DIFF
--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -718,6 +718,10 @@ const Flagsmith = class {
             this.flags = state.flags || this.flags;
             this.identity = state.identity || this.identity;
             this.traits = state.traits || this.traits;
+            this.withTraits = {
+                ...(this.withTraits||{}),
+                ...this.traits,
+            };
             this.evaluationEvent = state.evaluationEvent || this.evaluationEvent;
             this.log("setState called", this)
         }

--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -719,8 +719,7 @@ const Flagsmith = class {
             this.identity = state.identity || this.identity;
             this.traits = state.traits || this.traits;
             this.withTraits = {
-                ...(this.withTraits||{}),
-                ...this.traits,
+               ...this.traits
             };
             this.evaluationEvent = state.evaluationEvent || this.evaluationEvent;
             this.log("setState called", this)

--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -719,7 +719,8 @@ const Flagsmith = class {
             this.identity = state.identity || this.identity;
             this.traits = state.traits || this.traits;
             this.withTraits = {
-               ...this.traits
+                ...(this.withTraits||{}),
+                ...this.traits,
             };
             this.evaluationEvent = state.evaluationEvent || this.evaluationEvent;
             this.log("setState called", this)

--- a/lib/flagsmith-es/package.json
+++ b/lib/flagsmith-es/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith-es",
-  "version": "3.23.2",
+  "version": "3.23.3",
   "description": "Feature flagging to support continuous development. This is an esm equivalent of the standard flagsmith npm module.",
   "main": "./index.js",
   "type": "module",

--- a/lib/flagsmith/package.json
+++ b/lib/flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith",
-  "version": "3.23.2",
+  "version": "3.23.3",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {

--- a/lib/react-native-flagsmith/package.json
+++ b/lib/react-native-flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flagsmith",
-  "version": "3.23.2",
+  "version": "3.23.3",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {


### PR DESCRIPTION
The Open feature client needs to set traits silently, without calling setTraits(). This allows you to send traits in the next call based on the traits provided in setState.