### PR TITLE
fix: Silently handle request response miss-matches

### DIFF
--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -85,7 +85,11 @@ const Flagsmith = class {
                 isFetching: true
             })
         }
-        const handleResponse = ({ flags: features, traits }: IFlagsmithResponse) => {
+        const handleResponse = (response: IFlagsmithResponse | null) => {
+            if(!response) {
+                return // getJSON returned null due to request/response mismatch
+            }
+            let { flags: features, traits }: IFlagsmithResponse = response
             this.isLoading = false;
             if (identity) {
                 this.withTraits = null;
@@ -188,7 +192,7 @@ const Flagsmith = class {
             ])
                 .then((res) => {
                     this.withTraits = null
-                    return handleResponse(res[0] as IFlagsmithResponse)
+                    return handleResponse(res?.[0] as IFlagsmithResponse | null)
                 }).catch(({ message }) => {
                     const error = new Error(message)
                     return Promise.reject(error)

--- a/lib/flagsmith-es/package.json
+++ b/lib/flagsmith-es/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith-es",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Feature flagging to support continuous development. This is an esm equivalent of the standard flagsmith npm module.",
   "main": "./index.js",
   "type": "module",

--- a/lib/flagsmith/package.json
+++ b/lib/flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {

--- a/lib/react-native-flagsmith/package.json
+++ b/lib/react-native-flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flagsmith",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {


### PR DESCRIPTION
The SDK ignores responses that have come from an identity that has since changed. This was causing uncaught errors upstream. This PR adjusts the SDK to silently handle the errors, they will still be logged if enableLogs is true.
 
The easiest way to replicate this is by identifying multiple times with network throttling.