### PR TITLE
Support fallback for hasFeature, add options.skipAnalytics

### DIFF
--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -1,6 +1,7 @@
 import {
     DynatraceObject,
     GetValueOptions,
+    HasFeatureOptions,
     IDatadogRum,
     IFlags,
     IFlagsmith,
@@ -147,8 +148,8 @@ const Flagsmith = class {
                         javaLongOrObject: {},
                     }
                     Object.keys(this.flags).map((key) => {
-                        setDynatraceValue(traits, FLAGSMITH_CONFIG_ANALYTICS_KEY + key, this.getValue(key, {}, true))
-                        setDynatraceValue(traits, FLAGSMITH_FLAG_ANALYTICS_KEY + key, this.hasFeature(key, true))
+                        setDynatraceValue(traits, FLAGSMITH_CONFIG_ANALYTICS_KEY + key, this.getValue(key, { skipAnalytics: true }))
+                        setDynatraceValue(traits, FLAGSMITH_FLAG_ANALYTICS_KEY + key, this.hasFeature(key, { skipAnalytics: true }))
                     })
                     Object.keys(this.traits).map((key) => {
                         setDynatraceValue(traits, FLAGSMITH_TRAIT_ANALYTICS_KEY + key, this.getTrait(key))
@@ -584,7 +585,7 @@ const Flagsmith = class {
             res = flag.value;
         }
 
-        if (!skipAnalytics) {
+        if (!options?.skipAnalytics && !skipAnalytics) {
             this.evaluateFlag(key, "VALUE");
         }
 
@@ -652,13 +653,17 @@ const Flagsmith = class {
         }
     };
 
-    hasFeature = (key: string, skipAnalytics?: boolean) => {
+    hasFeature = (key: string, options?: HasFeatureOptions) => {
+        // Support legacy skipAnalytics boolean parameter
+        const usingNewOptions = typeof options === 'object'
         const flag = this.flags && this.flags[key.toLowerCase().replace(/ /g, '_')];
         let res = false;
-        if (flag && flag.enabled) {
+        if (!flag && usingNewOptions && typeof options.fallback !== 'undefined') {
+            res = options?.fallback
+        } else if (flag && flag.enabled) {
             res = true;
         }
-        if (!skipAnalytics) {
+        if ((usingNewOptions && !options.skipAnalytics) || !options) {
             this.evaluateFlag(key, "ENABLED");
         }
 

--- a/lib/flagsmith-es/package.json
+++ b/lib/flagsmith-es/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith-es",
-  "version": "4.0.3",
+  "version": "4.1.0",
   "description": "Feature flagging to support continuous development. This is an esm equivalent of the standard flagsmith npm module.",
   "main": "./index.js",
   "type": "module",

--- a/lib/flagsmith-es/package.json
+++ b/lib/flagsmith-es/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith-es",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Feature flagging to support continuous development. This is an esm equivalent of the standard flagsmith npm module.",
   "main": "./index.js",
   "type": "module",

--- a/lib/flagsmith/package.json
+++ b/lib/flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith",
-  "version": "4.0.3",
+  "version": "4.1.0",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {

--- a/lib/flagsmith/package.json
+++ b/lib/flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {

--- a/lib/react-native-flagsmith/package.json
+++ b/lib/react-native-flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flagsmith",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {

--- a/lib/react-native-flagsmith/package.json
+++ b/lib/react-native-flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flagsmith",
-  "version": "4.0.3",
+  "version": "4.1.0",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {

--- a/test/functions.test.ts
+++ b/test/functions.test.ts
@@ -1,0 +1,22 @@
+// Sample test
+import { defaultState, getFlagsmith, getStateToCheck, identityState } from './test-constants';
+
+describe.only('Flagsmith.functions', () => {
+
+    beforeEach(() => {
+        // Avoid mocks, but if you need to add them here
+    });
+    test('should use a fallback when the feature is undefined', async () => {
+        const onChange = jest.fn()
+        const {flagsmith,initConfig, AsyncStorage,mockFetch} = getFlagsmith({onChange})
+        await flagsmith.init(initConfig);
+
+        expect(flagsmith.getValue("deleted_feature",{fallback:"foo"})).toBe("foo");
+        expect(flagsmith.hasFeature("deleted_feature",{fallback:true})).toBe(true);
+        expect(flagsmith.hasFeature("deleted_feature",{fallback:false})).toBe(false);
+        expect(flagsmith.hasFeature("font_size",{fallback:false})).toBe(true);
+        expect(flagsmith.getValue("font_size",{fallback:100})).toBe(16);
+        expect(flagsmith.getValue("font_size")).toBe(16);
+        expect(flagsmith.hasFeature("font_size")).toBe(true);
+    })
+});

--- a/test/functions.test.ts
+++ b/test/functions.test.ts
@@ -1,7 +1,7 @@
 // Sample test
-import { defaultState, getFlagsmith, getStateToCheck, identityState } from './test-constants';
+import { getFlagsmith } from './test-constants';
 
-describe.only('Flagsmith.functions', () => {
+describe('Flagsmith.functions', () => {
 
     beforeEach(() => {
         // Avoid mocks, but if you need to add them here

--- a/types.d.ts
+++ b/types.d.ts
@@ -17,9 +17,15 @@ export declare type IFlags<F extends string = string> = Record<F, IFlagsmithFeat
 export declare type ITraits<T extends string = string> = Record<T, IFlagsmithTrait>;
 
 export declare type GetValueOptions<T = Array<any> | object> = {
-    json?: boolean;
+    skipAnalytics?: boolean
+    json?: boolean
     fallback?: T
 }
+
+export declare type HasFeatureOptions = {
+    skipAnalytics?: boolean
+    fallback?: boolean
+} | boolean
 
 
 export interface IRetrieveInfo {
@@ -149,14 +155,35 @@ export interface IFlagsmith<F extends string = string, T extends string = string
      */
     stopListening: () => void;
     /**
-     * Get the whether a flag is enabled e.g. flagsmith.hasFeature("powerUserFeature")
+     * Returns whether a feature is enabled, or a fallback value if it does not exist.
+     * @param {HasFeatureOptions} [optionsOrSkipAnalytics=false] If `true`, will not track analytics for this flag
+     * evaluation. Using a boolean for this parameter is deprecated - use `{ skipAnalytics: true }` instead.
+     * @param [optionsOrSkipAnalytics.fallback=false] Returns this value if the feature does not exist.
+     * @param [optionsOrSkipAnalytics.skipAnalytics=false] If `true`, do not track analytics for this feature evaluation.
+     * @example
+     * flagsmith.hasFeature("power_user_feature")
+     * @example
+     * flagsmith.hasFeature("enabled_by_default_feature", { fallback: true })
      */
-    hasFeature: (key: F) => boolean;
+    hasFeature: (key: F, optionsOrSkipAnalytics?: HasFeatureOptions) => boolean;
 
     /**
-     * Get the value of a particular remote config e.g. flagsmith.getValue("font_size")
+     * Returns the value of a feature, or a fallback value.
+     * @param [options.json=false] Deserialise the feature value using `JSON.parse` and return the result or `options.fallback`.
+     * @param [options.fallback=null] Return this value in any of these cases:
+     * * The feature does not exist.
+     * * The feature has no value.
+     * * `options.json` is `true` and the feature's value is not valid JSON.
+     * @param [options.skipAnalytics=false] If `true`, do not track analytics for this feature evaluation.
+     * @param [skipAnalytics=false] Deprecated - use `options.skipAnalytics` instead.
+     * @example
+     * flagsmith.getValue("remote_config") // "{\"hello\":\"world\"}"
+     * flagsmith.getValue("remote_config", { json: true }) // { hello: "world" }
+     * @example
+     * flagsmith.getValue("font_size") // "12px"
+     * flagsmith.getValue("font_size", { json: true, fallback: "8px" }) // "8px"
      */
-    getValue<T = IFlagsmithValue>(key: F, options?: GetValueOptions<T>): IFlagsmithValue<T>;
+    getValue<T = IFlagsmithValue>(key: F, options?: GetValueOptions<T>, skipAnalytics?: boolean): IFlagsmithValue<T>;
 
     /**
      * Get the value of a particular trait for the identified user


### PR DESCRIPTION
This change solves https://github.com/Flagsmith/flagsmith-js-client/issues/243 by adding a `fallback` option to `hasFeature`, instead of changing how `defaultFlags` works. It also deprecates the current way of using `skipAnalytics` but preserves backwards compatibility.

I chose to move `skipAnalytics` into an option property instead of a boolean parameter for both `getValue` and `hasFeature`. If we chose to only add parameters to `hasFeature` and not deprecate anything, these would be our options:

1. Add a `{ fallback: boolean }` parameter

```ts
// forces you to specify a value for skipAnalytics, which is weird
hasFeature("my_bool", false, { fallback: true })

// looks inconsistent with getValue
getValue("my_feat", { fallback: "foo" }, true)
```

2. Add a boolean parameter for the fallback

```ts
// easy to confuse which is skipAnalytics and which is the fallback
hasFeature("my_bool", false, true)

// easy to confuse with OpenFeature's getBooleanValue
// https://openfeature.dev/docs/reference/concepts/evaluation-api/#basic-evaluation
getBooleanValue("my_bool", true)

// still inconsistent with getValue
getValue("my_feat", { fallback: "foo" })
```

Putting everything under an option object also lets us add more options if needed without worrying about backwards compatibility or parameter placement/ergonomics.

The new way of using these methods would be:

```ts
hasFeature("my_bool", { fallback: true, skipAnalytics: true })
getValue("my_feat", { fallback: "foo", skipAnalytics: true })
```

Missing from this PR:

* Tests - I didn't see any tests for `hasFeature` or `getValue` though
* Docs - wanted to align on the implementation first