### PR TITLE
fix: Merge flagsmith.init traits with cached values

### DIFF
--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -420,7 +420,14 @@ const Flagsmith = class {
                                         cachePopulated = true;
                                         traitsChanged = getChanges(this.traits, json.traits)
                                         flagsChanged = getChanges(this.flags, json.flags)
-                                        this.setState(json);
+                                        // When populating state from cache, we merge traits passed in flagsmith.init
+                                        this.setState({
+                                            ...json,
+                                            traits: ({
+                                                ...(json.traits||{}),
+                                                ...(traits||{})
+                                            })
+                                        });
                                         this.log("Retrieved flags from cache", json);
                                     }
                                 }

--- a/lib/flagsmith-es/package.json
+++ b/lib/flagsmith-es/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith-es",
-  "version": "4.0.3",
+  "version": "4.0.4-beta.1",
   "description": "Feature flagging to support continuous development. This is an esm equivalent of the standard flagsmith npm module.",
   "main": "./index.js",
   "type": "module",

--- a/lib/flagsmith/package.json
+++ b/lib/flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith",
-  "version": "4.0.3",
+  "version": "4.0.4-beta.1",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {

--- a/lib/react-native-flagsmith/package.json
+++ b/lib/react-native-flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flagsmith",
-  "version": "4.0.3",
+  "version": "4.0.4-beta.1",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -165,6 +165,24 @@ describe('Cache', () => {
             ...defaultStateAlt,
         });
     });
+    test('should not get flags from API when skipAPI is set', async () => {
+        const onChange = jest.fn();
+        const { flagsmith, initConfig, AsyncStorage, mockFetch } = getFlagsmith({
+            cacheFlags: true,
+            onChange,
+            cacheOptions: { ttl: 1000, skipAPI: true },
+        });
+        await AsyncStorage.setItem('BULLET_TRAIN_DB', JSON.stringify({
+            ...defaultStateAlt,
+            ts: new Date().valueOf(),
+        }));
+        await flagsmith.init(initConfig);
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(mockFetch).toHaveBeenCalledTimes(0);
+        expect(getStateToCheck(flagsmith.getState())).toEqual({
+            ...defaultStateAlt,
+        });
+    });
     test('should validate flags are unchanged when fetched', async () => {
         const onChange = jest.fn();
         const { flagsmith, initConfig, AsyncStorage, mockFetch } = getFlagsmith({
@@ -281,5 +299,27 @@ describe('Cache', () => {
                 'source': 'CACHE',
             },
         );
+    });
+    test('should merge any newly passed traits with cache', async () => {
+        const onChange = jest.fn();
+        const { flagsmith, initConfig, AsyncStorage } = getFlagsmith({
+            onChange,
+            cacheFlags: true,
+            preventFetch: true,
+        });
+        const storage = new SyncStorageMock();
+        await storage.setItem('BULLET_TRAIN_DB', JSON.stringify({
+            ...identityState,
+        }));
+        const ts = Date.now();
+        await flagsmith.init({
+            ...initConfig,
+            traits: { ts },
+            AsyncStorage: storage,
+        });
+        expect(flagsmith.getAllTraits()).toEqual({
+            ...identityState.traits,
+            ts
+        })
     });
 });


### PR DESCRIPTION
Fixes https://github.com/Flagsmith/flagsmith-js-client/issues/242. flagsmith.init traits will be merged with cache when it is read.