### PR TITLE
#201 (feat): added envId to the storage key and added property to cacheOptions to customize the key

### DIFF
--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -37,8 +37,8 @@ type RequestOptions = {
 }
 
 let AsyncStorage: AsyncStorageType = null;
-const DEFAULT_FLAGSMITH_KEY = "BULLET_TRAIN_DB";
-const DEFAULT_FLAGSMITH_EVENT = "BULLET_TRAIN_EVENT";
+const DEFAULT_FLAGSMITH_KEY = "FLAGSMITH_DB";
+const DEFAULT_FLAGSMITH_EVENT = "FLAGSMITH_EVENT";
 let FlagsmithKey = DEFAULT_FLAGSMITH_KEY;
 let FlagsmithEvent = DEFAULT_FLAGSMITH_EVENT;
 const defaultAPI = 'https://edge.api.flagsmith.com/api/v1/';
@@ -396,6 +396,27 @@ const Flagsmith = class {
                             }
                         }
                     });
+                }
+            }
+
+            const migrateAsyncStorageCache = async () => {
+                try {
+                    // Check if data exists under the old key using getItemSync or getItem
+                    const oldData = AsyncStorage?.getItemSync ?
+                        AsyncStorage.getItemSync(oldKey) :
+                        await AsyncStorage?.getItem(oldKey);
+
+                    if (oldData) {
+                        // Migrate the data to the new key
+                        await AsyncStorage?.setItem(newKey, oldData);
+
+                        // Optionally, you can remove the old key after migration
+                        await AsyncStorage?.removeItem(oldKey);
+
+                        console.log(`Cache migrated from '${oldKey}' to '${newKey}'.`);
+                    }
+                } catch (error) {
+                    console.error(`Failed to migrate cache from '${oldKey}' to '${newKey}':`, error);
                 }
             }
 

--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -399,27 +399,6 @@ const Flagsmith = class {
                 }
             }
 
-            const migrateAsyncStorageCache = async () => {
-                try {
-                    // Check if data exists under the old key using getItemSync or getItem
-                    const oldData = AsyncStorage?.getItemSync ?
-                        AsyncStorage.getItemSync(oldKey) :
-                        await AsyncStorage?.getItem(oldKey);
-
-                    if (oldData) {
-                        // Migrate the data to the new key
-                        await AsyncStorage?.setItem(newKey, oldData);
-
-                        // Optionally, you can remove the old key after migration
-                        await AsyncStorage?.removeItem(oldKey);
-
-                        console.log(`Cache migrated from '${oldKey}' to '${newKey}'.`);
-                    }
-                } catch (error) {
-                    console.error(`Failed to migrate cache from '${oldKey}' to '${newKey}':`, error);
-                }
-            }
-
             //If the user specified default flags emit a changed event immediately
             if (cacheFlags) {
                 if (AsyncStorage && this.canUseStorage) {

--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -37,8 +37,10 @@ type RequestOptions = {
 }
 
 let AsyncStorage: AsyncStorageType = null;
-const FLAGSMITH_KEY = "BULLET_TRAIN_DB";
-const FLAGSMITH_EVENT = "BULLET_TRAIN_EVENT";
+const DEFAULT_FLAGSMITH_KEY = "BULLET_TRAIN_DB";
+const DEFAULT_FLAGSMITH_EVENT = "BULLET_TRAIN_EVENT";
+let FlagsmithKey = DEFAULT_FLAGSMITH_KEY;
+let FlagsmithEvent = DEFAULT_FLAGSMITH_EVENT;
 const defaultAPI = 'https://edge.api.flagsmith.com/api/v1/';
 let eventSource: typeof EventSource;
 const initError = function(caller: string) {
@@ -320,6 +322,10 @@ const Flagsmith = class {
             this.ticks = 10000;
             this.timer = this.enableLogs ? new Date().valueOf() : null;
             this.cacheFlags = typeof AsyncStorage !== 'undefined' && !!cacheFlags;
+
+            FlagsmithKey = cacheOptions?.storageKey || DEFAULT_FLAGSMITH_KEY + "_" + environmentID;
+            FlagsmithEvent = DEFAULT_FLAGSMITH_EVENT + "_" + environmentID;
+
             if (_AsyncStorage) {
                 AsyncStorage = _AsyncStorage;
             }
@@ -360,7 +366,7 @@ const Flagsmith = class {
             }
 
             if (AsyncStorage && this.canUseStorage) {
-                AsyncStorage.getItem(FLAGSMITH_EVENT)
+                AsyncStorage.getItem(FlagsmithEvent)
                     .then((res)=>{
                         try {
                             this.evaluationEvent = JSON.parse(res!) || {}
@@ -377,7 +383,7 @@ const Flagsmith = class {
                 }
 
                 if (AsyncStorage && this.canUseStorage) {
-                    AsyncStorage.getItem(FLAGSMITH_EVENT, (err, res) => {
+                    AsyncStorage.getItem(FlagsmithEvent, (err, res) => {
                         if (res) {
                             const json = JSON.parse(res);
                             if (json[this.environmentID]) {
@@ -469,7 +475,7 @@ const Flagsmith = class {
                         }
                     };
                     try {
-                        const res = AsyncStorage.getItemSync? AsyncStorage.getItemSync(FLAGSMITH_KEY) : await AsyncStorage.getItem(FLAGSMITH_KEY);
+                        const res = AsyncStorage.getItemSync? AsyncStorage.getItemSync(FlagsmithKey) : await AsyncStorage.getItem(FlagsmithKey);
                         await onRetrievedStorage(null, res)
                     } catch (e) {}
                 }
@@ -685,7 +691,7 @@ const Flagsmith = class {
             this.ts = new Date().valueOf();
             const state = JSON.stringify(this.getState());
             this.log('Setting storage', state);
-            AsyncStorage!.setItem(FLAGSMITH_KEY, state);
+            AsyncStorage!.setItem(FlagsmithKey, state);
         }
     }
 
@@ -749,7 +755,7 @@ const Flagsmith = class {
     private updateEventStorage() {
         if (this.enableAnalytics) {
             const events = JSON.stringify(this.getState().evaluationEvent);
-            AsyncStorage!.setItem(FLAGSMITH_EVENT, events);
+            AsyncStorage!.setItem(FlagsmithEvent, events);
         }
     }
 

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1,7 +1,7 @@
 // Sample test
 import {
     defaultState,
-    defaultStateAlt,
+    defaultStateAlt, FLAGSMITH_KEY,
     getFlagsmith,
     getStateToCheck,
     identityState,
@@ -32,7 +32,21 @@ describe('Cache', () => {
             onChange,
         });
         await flagsmith.init(initConfig);
-        const cache = await AsyncStorage.getItem('BULLET_TRAIN_DB');
+        const cache = await AsyncStorage.getItem(FLAGSMITH_KEY);
+        expect(getStateToCheck(JSON.parse(`${cache}`))).toEqual(defaultState);
+    });
+    test('should set cache after init with custom key', async () => {
+        const onChange = jest.fn();
+        const customKey = 'custom_key';
+        const { flagsmith, initConfig, AsyncStorage, mockFetch } = getFlagsmith({
+            cacheFlags: true,
+            cacheOptions: {
+                storageKey: customKey,
+            },
+            onChange,
+        });
+        await flagsmith.init(initConfig);
+        const cache = await AsyncStorage.getItem(customKey);
         expect(getStateToCheck(JSON.parse(`${cache}`))).toEqual(defaultState);
     });
     test('should call onChange with cache then eventually with an API response', async () => {
@@ -52,7 +66,7 @@ describe('Cache', () => {
             cacheFlags: true,
             onChange,
         });
-        await AsyncStorage.setItem('BULLET_TRAIN_DB', JSON.stringify(defaultStateAlt));
+        await AsyncStorage.setItem(FLAGSMITH_KEY, JSON.stringify(defaultStateAlt));
         await flagsmith.init(initConfig);
 
         // Flags retrieved from cache
@@ -85,7 +99,7 @@ describe('Cache', () => {
             identity: testIdentity,
             onChange,
         });
-        await AsyncStorage.setItem('BULLET_TRAIN_DB', JSON.stringify({
+        await AsyncStorage.setItem(FLAGSMITH_KEY, JSON.stringify({
             ...defaultStateAlt,
             identity: 'bad_identity',
         }));
@@ -101,7 +115,7 @@ describe('Cache', () => {
             onChange,
             cacheOptions: { ttl: 1 },
         });
-        await AsyncStorage.setItem('BULLET_TRAIN_DB', JSON.stringify({
+        await AsyncStorage.setItem(FLAGSMITH_KEY, JSON.stringify({
             ...defaultStateAlt,
             ts: new Date().valueOf() - 100,
         }));
@@ -119,7 +133,7 @@ describe('Cache', () => {
             onChange,
             cacheOptions: { ttl: 1000 },
         });
-        await AsyncStorage.setItem('BULLET_TRAIN_DB', JSON.stringify({
+        await AsyncStorage.setItem(FLAGSMITH_KEY, JSON.stringify({
             ...defaultStateAlt,
             ts: new Date().valueOf(),
         }));
@@ -136,7 +150,7 @@ describe('Cache', () => {
             cacheFlags: false,
             onChange,
         });
-        await AsyncStorage.setItem('BULLET_TRAIN_DB', JSON.stringify({
+        await AsyncStorage.setItem(FLAGSMITH_KEY, JSON.stringify({
             ...defaultStateAlt,
             ts: new Date().valueOf(),
         }));
@@ -154,7 +168,7 @@ describe('Cache', () => {
             onChange,
             cacheOptions: { ttl: 1000, skipAPI: true },
         });
-        await AsyncStorage.setItem('BULLET_TRAIN_DB', JSON.stringify({
+        await AsyncStorage.setItem(FLAGSMITH_KEY, JSON.stringify({
             ...defaultStateAlt,
             ts: new Date().valueOf(),
         }));
@@ -172,7 +186,7 @@ describe('Cache', () => {
             cacheFlags: true,
             preventFetch: true,
         });
-        await AsyncStorage.setItem('BULLET_TRAIN_DB', JSON.stringify({
+        await AsyncStorage.setItem(FLAGSMITH_KEY, JSON.stringify({
             ...defaultState,
         }));
         await flagsmith.init(initConfig);
@@ -218,7 +232,7 @@ describe('Cache', () => {
             preventFetch: true,
             defaultFlags: defaultState.flags,
         });
-        await AsyncStorage.setItem('BULLET_TRAIN_DB', JSON.stringify({
+        await AsyncStorage.setItem(FLAGSMITH_KEY, JSON.stringify({
             ...defaultState,
         }));
         await flagsmith.init(initConfig);
@@ -264,7 +278,7 @@ describe('Cache', () => {
             preventFetch: true,
         });
         const storage = new SyncStorageMock();
-        await storage.setItem('BULLET_TRAIN_DB', JSON.stringify({
+        await storage.setItem(FLAGSMITH_KEY, JSON.stringify({
             ...defaultState,
         }));
         flagsmith.init({

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1,7 +1,8 @@
 // Sample test
 import {
     defaultState,
-    defaultStateAlt, FLAGSMITH_KEY,
+    defaultStateAlt,
+    FLAGSMITH_KEY,
     getFlagsmith,
     getStateToCheck,
     identityState,
@@ -179,24 +180,7 @@ describe('Cache', () => {
             ...defaultStateAlt,
         });
     });
-    test('should not get flags from API when skipAPI is set', async () => {
-        const onChange = jest.fn();
-        const { flagsmith, initConfig, AsyncStorage, mockFetch } = getFlagsmith({
-            cacheFlags: true,
-            onChange,
-            cacheOptions: { ttl: 1000, skipAPI: true },
-        });
-        await AsyncStorage.setItem('BULLET_TRAIN_DB', JSON.stringify({
-            ...defaultStateAlt,
-            ts: new Date().valueOf(),
-        }));
-        await flagsmith.init(initConfig);
-        expect(onChange).toHaveBeenCalledTimes(1);
-        expect(mockFetch).toHaveBeenCalledTimes(0);
-        expect(getStateToCheck(flagsmith.getState())).toEqual({
-            ...defaultStateAlt,
-        });
-    });
+
     test('should validate flags are unchanged when fetched', async () => {
         const onChange = jest.fn();
         const { flagsmith, initConfig, AsyncStorage, mockFetch } = getFlagsmith({
@@ -322,7 +306,7 @@ describe('Cache', () => {
             preventFetch: true,
         });
         const storage = new SyncStorageMock();
-        await storage.setItem('BULLET_TRAIN_DB', JSON.stringify({
+        await storage.setItem(FLAGSMITH_KEY, JSON.stringify({
             ...identityState,
         }));
         const ts = Date.now();
@@ -333,7 +317,7 @@ describe('Cache', () => {
         });
         expect(flagsmith.getAllTraits()).toEqual({
             ...identityState.traits,
-            ts
-        })
+            ts,
+        });
     });
 });

--- a/test/default-flags.test.ts
+++ b/test/default-flags.test.ts
@@ -1,5 +1,5 @@
 // Sample test
-import { defaultState, defaultStateAlt, getFlagsmith, getStateToCheck } from './test-constants';
+import { defaultState, defaultStateAlt, FLAGSMITH_KEY, getFlagsmith, getStateToCheck } from './test-constants';
 import { IFlags } from '../types';
 
 describe('Default Flags', () => {
@@ -51,7 +51,7 @@ describe('Default Flags', () => {
             cacheFlags: true,
             defaultFlags: {...defaultFlags, ...itemsToRemove},
         });
-        await AsyncStorage.setItem('BULLET_TRAIN_DB', JSON.stringify({
+        await AsyncStorage.setItem(FLAGSMITH_KEY, JSON.stringify({
             ...defaultState,
             flags: {
                 ...defaultFlags,

--- a/test/test-constants.ts
+++ b/test/test-constants.ts
@@ -3,7 +3,7 @@ import MockAsyncStorage from './mocks/async-storage-mock';
 import { createFlagsmithInstance } from '../lib/flagsmith';
 import fetch from 'isomorphic-unfetch';
 export const environmentID = 'QjgYur4LQTwe5HpvbvhpzK'; // Flagsmith Demo Projects
-export const FLAGSMITH_KEY = 'BULLET_TRAIN_DB' + "_" + environmentID;
+export const FLAGSMITH_KEY = 'FLAGSMITH_DB' + "_" + environmentID;
 export const defaultState = {
     api: 'https://edge.api.flagsmith.com/api/v1/',
     environmentID,

--- a/test/test-constants.ts
+++ b/test/test-constants.ts
@@ -3,7 +3,7 @@ import MockAsyncStorage from './mocks/async-storage-mock';
 import { createFlagsmithInstance } from '../lib/flagsmith';
 import fetch from 'isomorphic-unfetch';
 export const environmentID = 'QjgYur4LQTwe5HpvbvhpzK'; // Flagsmith Demo Projects
-
+export const FLAGSMITH_KEY = 'BULLET_TRAIN_DB' + "_" + environmentID;
 export const defaultState = {
     api: 'https://edge.api.flagsmith.com/api/v1/',
     environmentID,

--- a/types.d.ts
+++ b/types.d.ts
@@ -46,6 +46,7 @@ export interface IState<F extends string = string, T extends string = string> {
 declare type ICacheOptions = {
     ttl?: number;
     skipAPI?: boolean;
+    storageKey?: string;
 };
 
 export declare type IDatadogRum = {


### PR DESCRIPTION
### Problem:
A limitation was found in the `clientSide cacheFlags` implementation. The issue arises because the same key is always used in `localStorage` cited in #201, which can lead to conflicts when the system is used in the context of micro frontends (MFEs) or with multiple instances. This key competition in `localStorage` can cause negative effects, such as data being overwritten or cache inconsistencies.

### Resolution:
To address this issue, it was proposed to allow the `localStorage` key name to be explicitly defined or for it to take into account the `environmentID`. This would solve the problem by ensuring that each instance or environment has a unique key, preventing conflicts.

### Changes Implemented:
1. **Concatenating `environmentID` to the `localStorage` Key:** To resolve the initial problem, the key used in `localStorage` was modified to include the `environmentID`. This ensures that different environments use distinct keys, eliminating competition in local storage.

2. **New `storageKey` Property in `cacheOptions` Object:** During the process, an additional issue was identified: two or more instances with the same `environmentID` but identifying different users could still cause conflicts. To handle this scenario and increase flexibility, the `storageKey` property was added to the `cacheOptions` object, which is passed during initialization. This allows the `localStorage` key to be customized for each instance, ensuring the necessary distinction between different usage contexts.

### Important Note:
When deploying the new version of the SDK with these changes, there may be a loss of compatibility with the old key used to retrieve the cache. It’s important to consider this when upgrading, as the old cache data may not be accessible using the new key format.

### Conclusion:
These changes enhance the flexibility and robustness of the system when handling cache in complex environments, such as applications using micro frontends or multiple instances. Now, conflicts in `localStorage` can be avoided, and the cache can function correctly for each specific context.

> All tests were run successfully