### PR TITLE
fix: race condition within flagsmith.init responses

### DIFF
--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -86,8 +86,9 @@ const Flagsmith = class {
                 isFetching: true
             })
         }
+        const previousIdentity = `${this.identity}`;
         const handleResponse = (response: IFlagsmithResponse | null) => {
-            if(!response) {
+            if(!response || previousIdentity !== `${this.identity}`) {
                 return // getJSON returned null due to request/response mismatch
             }
             let { flags: features, traits }: IFlagsmithResponse = response

--- a/lib/flagsmith-es/package.json
+++ b/lib/flagsmith-es/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith-es",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Feature flagging to support continuous development. This is an esm equivalent of the standard flagsmith npm module.",
   "main": "./index.js",
   "type": "module",

--- a/lib/flagsmith/package.json
+++ b/lib/flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {

--- a/lib/react-native-flagsmith/package.json
+++ b/lib/react-native-flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flagsmith",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {

--- a/test/react.test.tsx
+++ b/test/react.test.tsx
@@ -124,7 +124,7 @@ describe('FlagsmithProvider', () => {
             expect(JSON.parse(screen.getByTestId("flags").innerHTML)).toEqual(removeIds(defaultState.flags));
         });
     });
-    it('handles race condition of init returning after identify', async () => {
+    it('ignores init response if identify gets called and resolves first', async () => {
 
         const onChange = jest.fn();
         const {flagsmith,initConfig, mockFetch} = getFlagsmith({onChange})
@@ -135,7 +135,7 @@ describe('FlagsmithProvider', () => {
                 id: 1,
                 name: "hero"
             }
-        }],300) // never resolves
+        }],300) // resolves after flagsmith.identify, it should be ignored
 
         render(
             <FlagsmithProvider flagsmith={flagsmith} options={initConfig}>

--- a/test/test-constants.ts
+++ b/test/test-constants.ts
@@ -2,6 +2,8 @@ import { IInitConfig, IState } from '../lib/flagsmith/types';
 import MockAsyncStorage from './mocks/async-storage-mock';
 import { createFlagsmithInstance } from '../lib/flagsmith';
 import fetch from 'isomorphic-unfetch';
+import type { ModuleMocker } from 'jest-mock';
+import Mock = jest.Mock;
 export const environmentID = 'QjgYur4LQTwe5HpvbvhpzK'; // Flagsmith Demo Projects
 
 export const defaultState = {
@@ -79,4 +81,12 @@ export function getFlagsmith(config: Partial<IInitConfig> = {}) {
         ...config,
     };
     return { flagsmith, initConfig, mockFetch, AsyncStorage };
+}
+export const delay = (ms:number) => new Promise((resolve) => setTimeout(resolve, ms));
+export function getMockFetchWithValue(mockFn:Mock, resolvedValue:object, ms=0) {
+    mockFn.mockReturnValueOnce(delay(ms).then(()=>Promise.resolve({
+        status:200,
+        text: () => Promise.resolve(JSON.stringify(resolvedValue)), // Mock json() to return the mock response
+        json: () => Promise.resolve(resolvedValue), // Mock json() to return the mock response
+    })))
 }


### PR DESCRIPTION
If flagsmith.init resolved after flagsmith.identify it would cause a react application to see ``{}`` for the flags, the sdk will now ignore any API responses that do not match the current identity.