### PR TITLE
add loadStale cache option to load already expired cache data

### DIFF
--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -257,7 +257,7 @@ const Flagsmith = class {
     traits:ITraits|null= null
     dtrum= null
     withTraits?: ITraits|null= null
-    cacheOptions = {ttl:0, skipAPI: false}
+    cacheOptions = {ttl:0, skipAPI: false, loadStale: false}
     async init(config: IInitConfig) {
         try {
             const {
@@ -306,7 +306,7 @@ const Flagsmith = class {
             this.identity = identity;
             this.withTraits = traits;
             this.enableLogs = enableLogs || false;
-            this.cacheOptions = cacheOptions ? { skipAPI: !!cacheOptions.skipAPI, ttl: cacheOptions.ttl || 0 } : this.cacheOptions;
+            this.cacheOptions = cacheOptions ? { skipAPI: !!cacheOptions.skipAPI, ttl: cacheOptions.ttl || 0, loadStale: !!cacheOptions.loadStale } : this.cacheOptions;
             if (!this.cacheOptions.ttl && this.cacheOptions.skipAPI) {
                 console.warn("Flagsmith: you have set a cache ttl of 0 and are skipping API calls, this means the API will not be hit unless you clear local storage.")
             }
@@ -412,9 +412,13 @@ const Flagsmith = class {
                                     }
                                     if (this.cacheOptions.ttl) {
                                         if (!json.ts || (new Date().valueOf() - json.ts > this.cacheOptions.ttl)) {
-                                            if (json.ts) {
+                                            if (json.ts && !this.cacheOptions.loadStale) {
                                                 this.log("Ignoring cache, timestamp is too old ts:" + json.ts + " ttl: " + this.cacheOptions.ttl + " time elapsed since cache: " + (new Date().valueOf()-json.ts)+"ms")
                                                 setState = false;
+                                            }
+                                            else if (json.ts && this.cacheOptions.loadStale) {
+                                                this.log("Loading stale cache, timestamp ts:" + json.ts + " ttl: " + this.cacheOptions.ttl + " time elapsed since cache: " + (new Date().valueOf()-json.ts)+"ms")
+                                                setState = true;
                                             }
                                         }
                                     }

--- a/lib/flagsmith-es/package.json
+++ b/lib/flagsmith-es/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith-es",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Feature flagging to support continuous development. This is an esm equivalent of the standard flagsmith npm module.",
   "main": "./index.js",
   "type": "module",

--- a/lib/flagsmith/package.json
+++ b/lib/flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {

--- a/lib/react-native-flagsmith/package.json
+++ b/lib/react-native-flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flagsmith",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -112,6 +112,24 @@ describe('Cache', () => {
             ...defaultState,
         });
     });
+    test('should not ignore cache with expired ttl and loadStale is set', async () => {
+        const onChange = jest.fn();
+        const { flagsmith, initConfig, AsyncStorage, mockFetch } = getFlagsmith({
+            cacheFlags: true,
+            onChange,
+            cacheOptions: { ttl: 1, loadStale: true },
+        });
+        await AsyncStorage.setItem('BULLET_TRAIN_DB', JSON.stringify({
+            ...defaultStateAlt,
+            ts: new Date().valueOf() - 100,
+        }));
+        await flagsmith.init(initConfig);
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(getStateToCheck(flagsmith.getState())).toEqual({
+            ...defaultStateAlt,
+        });
+    });
     test('should not ignore cache with valid ttl', async () => {
         const onChange = jest.fn();
         const { flagsmith, initConfig, AsyncStorage, mockFetch } = getFlagsmith({

--- a/types.d.ts
+++ b/types.d.ts
@@ -46,6 +46,7 @@ export interface IState<F extends string = string, T extends string = string> {
 declare type ICacheOptions = {
     ttl?: number;
     skipAPI?: boolean;
+    loadStale?: boolean;
 };
 
 export declare type IDatadogRum = {
@@ -233,6 +234,7 @@ export interface IFlagsmith<F extends string = string, T extends string = string
     cacheOptions: {
         ttl: number;
         skipAPI: boolean;
+        loadStale: boolean;
     };
     /**
      * Used internally, this is the api provided in flagsmith.init, defaults to our production API


### PR DESCRIPTION
Closes #250 with an additional `cacheOptions.loadStale` to load the current cached state even if it is expired.

