### PR TITLE
fix fetch from api after loading stale cache when skip api set

### DIFF
--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -404,6 +404,7 @@ const Flagsmith = class {
                             try {
                                 const json = JSON.parse(res);
                                 let cachePopulated = false;
+                                let staleCachePopulated = false;
                                 if (json && json.api === this.api && json.environmentID === this.environmentID) {
                                     let setState = true;
                                     if (this.identity && (json.identity !== this.identity)) {
@@ -418,6 +419,7 @@ const Flagsmith = class {
                                             }
                                             else if (json.ts && this.cacheOptions.loadStale) {
                                                 this.log("Loading stale cache, timestamp ts:" + json.ts + " ttl: " + this.cacheOptions.ttl + " time elapsed since cache: " + (new Date().valueOf()-json.ts)+"ms")
+                                                staleCachePopulated = true;
                                                 setState = true;
                                             }
                                         }
@@ -439,13 +441,14 @@ const Flagsmith = class {
                                 }
 
                                 if (cachePopulated) { // retrieved flags from local storage
-                                    const shouldFetchFlags = !preventFetch && (!this.cacheOptions.skipAPI||!cachePopulated)
+                                    // fetch the flags if the cache is stale, or if we're not skipping api on cache hits
+                                    const shouldFetchFlags = !preventFetch && (!this.cacheOptions.skipAPI || staleCachePopulated)
                                     this._onChange(null,
                                         { isFromServer: false, flagsChanged, traitsChanged },
                                         this._loadedState(null, FlagSource.CACHE, shouldFetchFlags)
                                     );
                                     this.oldFlags = this.flags;
-                                    if (this.cacheOptions.skipAPI && cachePopulated) {
+                                    if (this.cacheOptions.skipAPI && cachePopulated && !staleCachePopulated) {
                                         this.log("Skipping API, using cache")
                                     }
                                     if (shouldFetchFlags) {

--- a/lib/flagsmith-es/package.json
+++ b/lib/flagsmith-es/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith-es",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "Feature flagging to support continuous development. This is an esm equivalent of the standard flagsmith npm module.",
   "main": "./index.js",
   "type": "module",

--- a/lib/flagsmith/package.json
+++ b/lib/flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {

--- a/lib/react-native-flagsmith/package.json
+++ b/lib/react-native-flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flagsmith",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -201,6 +201,24 @@ describe('Cache', () => {
             ...defaultStateAlt,
         });
     });
+    test('should get flags from API when stale cache is loaded and skipAPI is set', async () => {
+        const onChange = jest.fn();
+        const { flagsmith, initConfig, AsyncStorage, mockFetch } = getFlagsmith({
+            cacheFlags: true,
+            onChange,
+            cacheOptions: { ttl: 1, skipAPI: true, loadStale: true },
+        });
+        await AsyncStorage.setItem('BULLET_TRAIN_DB', JSON.stringify({
+            ...defaultStateAlt,
+            ts: new Date().valueOf() - 100,
+        }));
+        await flagsmith.init(initConfig);
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(getStateToCheck(flagsmith.getState())).toEqual({
+            ...defaultStateAlt,
+        });
+    });
     test('should validate flags are unchanged when fetched', async () => {
         const onChange = jest.fn();
         const { flagsmith, initConfig, AsyncStorage, mockFetch } = getFlagsmith({


### PR DESCRIPTION
I think I missed this in the #251 PR.

In this PR I added tests and code to maintain the behaviour of getting from the api when the cache expired and after loading the stale cache.

There is bad case where you might end up with a forever stale cache by using the `loadStale: true`, when you expected that it always fetch when the cache has expired..

cc: @kyle-ssg 