### PR TITLE
fix: Evaluation context overwritten on init

### DIFF
--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -273,7 +273,7 @@ const Flagsmith = class {
     withTraits?: ITraits|null= null
     cacheOptions = {ttl:0, skipAPI: false, loadStale: false}
     async init(config: IInitConfig) {
-        const evaluationContext = toEvaluationContext(config.evaluationContext || {});
+        const evaluationContext = toEvaluationContext(config.evaluationContext || this.evaluationContext);
         try {
             const {
                 environmentID,

--- a/lib/flagsmith-es/package.json
+++ b/lib/flagsmith-es/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith-es",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Feature flagging to support continuous development. This is an esm equivalent of the standard flagsmith npm module.",
   "main": "./index.js",
   "type": "module",

--- a/lib/flagsmith/package.json
+++ b/lib/flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {

--- a/lib/react-native-flagsmith/package.json
+++ b/lib/react-native-flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flagsmith",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {


### PR DESCRIPTION
This fixes incorrect `init` behaviour that prevented users from using `identify` prior to calling `init`.