### PR TITLE
chore: add ReactNode type

### DIFF
--- a/react.tsx
+++ b/react.tsx
@@ -18,7 +18,7 @@ export type FlagsmithContextType = {
     flagsmith: IFlagsmith // The flagsmith instance
     options?: Parameters<IFlagsmith['init']>[0] // Initialisation options, if you do not provide this you will have to call init manually
     serverState?: IState
-    children: React.ReactElement[] | React.ReactElement;
+    children: React.ReactNode;
 }
 
 export const FlagsmithProvider: FC<FlagsmithContextType> = ({


### PR DESCRIPTION
Replaces ``React.ReactElement[] | React.ReactElement`` in favour of ``React.ReactNode``