### PR TITLE
fix: Un-deprecate `setTrait`, `setTraits` and `identify`

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -168,7 +168,7 @@ export interface IFlagsmith<F extends string = string, T extends string = string
      */
     getAllFlags: () => IFlags<F>;
     /**
-     * * @deprecated Please consider using evaluationContext.identity: {@link IFlagsmith.setContext}.
+     * Identify user, triggers a call to get flags if `flagsmith.init` has been called
      * */
     identify: (userId: string, traits?: Record<T, IFlagsmithValue>) => Promise<void>;
     /**

--- a/types.d.ts
+++ b/types.d.ts
@@ -231,12 +231,11 @@ export interface IFlagsmith<F extends string = string, T extends string = string
      */
     getAllTraits: () => Record<string, IFlagsmithValue>;
     /**
-     * * @deprecated Please consider using evaluationContext.identity: {@link IFlagsmith.setContext}.
+     * Set a specific trait for a given user id, triggers a call to get flags
      * */
     setTrait: (key: T, value: IFlagsmithTrait) => Promise<void>;
     /**
      * Set a key value set of traits for a given user, triggers a call to get flags
-     * @deprecated in favour of {@link IFlagsmith.setContext}.
      */
     setTraits: (traits: ITraits) => Promise<void>;
     /**


### PR DESCRIPTION
This pull request un-deprecates `setTrait`, `setTraits` and `identify` to match current documentation

Ref: https://github.com/Flagsmith/flagsmith-js-client/issues/275