### PR TITLE
chore: combine packages

### DIFF
--- a/lib/flagsmith-es/README.md
+++ b/lib/flagsmith-es/README.md
@@ -1,0 +1,5 @@
+<img width="100%" src="https://github.com/Flagsmith/flagsmith/raw/main/static-files/hero.png"/>
+
+# Flagsmith ESM Javascript Client
+
+This module is now deprecated and bundled into the [Flagsmith JS Client](https://www.npmjs.com/package/flagsmith).

--- a/lib/flagsmith-es/package.json
+++ b/lib/flagsmith-es/package.json
@@ -1,18 +1,21 @@
 {
   "name": "flagsmith-es",
-  "version": "8.0.2",
+  "version": "8.1.0",
   "description": "Feature flagging to support continuous development. This is an esm equivalent of the standard flagsmith npm module.",
   "main": "./index.js",
   "type": "module",
+  "scripts": {
+    "preinstall": "echo 'Flagsmith-es is now deprecated, please install the official Flagsmith package using \"npm install flagsmith\" instead of flagsmith-es.' && exit 1"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Flagsmith/flagsmith-js-client"
   },
   "keywords": [
-    "feature flagger",
+    "feature flags",
     "continuous deployment"
   ],
-  "author": "Flagsmith Ltd",
+  "author": "Flagsmith",
   "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/Flagsmith/flagsmith-js-client/issues"

--- a/lib/flagsmith-es/src/readme.md
+++ b/lib/flagsmith-es/src/readme.md
@@ -1,1 +1,0 @@
-This folder contains auto-generated sourcemaps.

--- a/lib/flagsmith/README.md
+++ b/lib/flagsmith/README.md
@@ -1,0 +1,30 @@
+<img width="100%" src="https://github.com/Flagsmith/flagsmith/raw/main/static-files/hero.png"/>
+
+# Flagsmith Javascript Client
+
+[![npm version](https://badge.fury.io/js/flagsmith.svg)](https://badge.fury.io/js/flagsmith)
+[![](https://data.jsdelivr.com/v1/package/npm/flagsmith/badge)](https://www.jsdelivr.com/package/npm/flagsmith)
+
+The web and SSR SDK clients for [https://www.flagsmith.com/](https://www.flagsmith.com/). Flagsmith allows you to manage feature flags and remote config across multiple projects, environments and organisations.
+
+## Adding to your project
+
+For full documentation visit [https://docs.flagsmith.com/clients/javascript/](https://docs.flagsmith.com/clients/javascript/)
+
+## Contributing
+
+Please read [CONTRIBUTING.md](https://gist.github.com/kyle-ssg/c36a03aebe492e45cbd3eefb21cb0486) for details on our code of conduct, and the process for submitting pull requests to us.
+
+## Getting Help
+
+If you encounter a bug or feature request we would like to hear about it. Before you submit an issue please search existing issues in order to prevent duplicates. 
+
+## Get in touch
+
+If you have any questions about our projects you can email <a href="mailto:support@flagsmith.com">support@flagsmith.com</a>.
+
+## Useful links
+
+[Website](https://www.flagsmith.com/)
+
+[Documentation](https://docs.flagsmith.com/)

--- a/lib/flagsmith/package.json
+++ b/lib/flagsmith/package.json
@@ -2,30 +2,30 @@
   "name": "flagsmith",
   "version": "8.1.0",
   "description": "Feature flagging to support continuous development",
-  "main": "./index.cjs.js",
+  "main": "./index.js",
   "module": "./index.es.js",
-  "browser": "./index.umd.js",
+  "browser": "./index.js",
   "types": "./index.d.ts",
   "exports": {
     ".": {
       "import": "./index.es.js",
-      "require": "./index.cjs.js",
-      "browser": "./index.umd.js"
+      "require": "./index.js",
+      "browser": "./index.js"
     },
     "./isomorphic": {
       "import": "./isomorphic.es.js",
-      "require": "./isomorphic.cjs.js",
-      "browser": "./isomorphic.umd.js"
+      "require": "./isomorphic.js",
+      "browser": "./isomorphic.js"
     },
     "./react": {
       "import": "./react.es.js",
-      "require": "./react.cjs.js",
-      "browser": "./react.umd.js"
+      "require": "./react.js",
+      "browser": "./react.js"
     },
     "./next-middleware": {
       "import": "./next-middleware.es.js",
-      "require": "./next-middleware.cjs.js",
-      "browser": "./next-middleware.umd.js"
+      "require": "./next-middleware.js",
+      "browser": "./next-middleware.js"
     }
   },
   "repository": {

--- a/lib/flagsmith/package.json
+++ b/lib/flagsmith/package.json
@@ -1,8 +1,33 @@
 {
   "name": "flagsmith",
-  "version": "8.0.2",
+  "version": "8.1.0",
   "description": "Feature flagging to support continuous development",
-  "main": "./index.js",
+  "main": "./index.cjs.js",
+  "module": "./index.es.js",
+  "browser": "./index.umd.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./index.es.js",
+      "require": "./index.cjs.js",
+      "browser": "./index.umd.js"
+    },
+    "./isomorphic": {
+      "import": "./isomorphic.es.js",
+      "require": "./isomorphic.cjs.js",
+      "browser": "./isomorphic.umd.js"
+    },
+    "./react": {
+      "import": "./react.es.js",
+      "require": "./react.cjs.js",
+      "browser": "./react.umd.js"
+    },
+    "./next-middleware": {
+      "import": "./next-middleware.es.js",
+      "require": "./next-middleware.cjs.js",
+      "browser": "./next-middleware.umd.js"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Flagsmith/flagsmith-js-client"
@@ -11,11 +36,10 @@
     "feature flagger",
     "continuous deployment"
   ],
-  "author": "Flagsmith Ltd",
+  "author": "Flagsmith",
   "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/Flagsmith/flagsmith-js-client/issues"
   },
-  "homepage": "https://flagsmith.com",
-  "types": "./index.d.ts"
+  "homepage": "https://flagsmith.com"
 }

--- a/lib/react-native-flagsmith/README.md
+++ b/lib/react-native-flagsmith/README.md
@@ -1,0 +1,30 @@
+<img width="100%" src="https://github.com/Flagsmith/flagsmith/raw/main/static-files/hero.png"/>
+
+# Flagsmith React Native Client
+
+[![npm version](https://badge.fury.io/js/flagsmith.svg)](https://badge.fury.io/js/react-native-flagsmith)
+[![](https://data.jsdelivr.com/v1/package/npm/flagsmith/badge)](https://www.jsdelivr.com/package/npm/flagsmith)
+
+The React Native SDK client for [https://www.flagsmith.com/](https://www.flagsmith.com/). Flagsmith allows you to manage feature flags and remote config across multiple projects, environments and organisations.
+
+## Adding to your project
+
+For full documentation visit [https://docs.flagsmith.com/clients/javascript/#npm-for-react-native](https://docs.flagsmith.com/clients/javascript/#npm-for-react-native)
+
+## Contributing
+
+Please read [CONTRIBUTING.md](https://gist.github.com/kyle-ssg/c36a03aebe492e45cbd3eefb21cb0486) for details on our code of conduct, and the process for submitting pull requests to us.
+
+## Getting Help
+
+If you encounter a bug or feature request we would like to hear about it. Before you submit an issue please search existing issues in order to prevent duplicates. 
+
+## Get in touch
+
+If you have any questions about our projects you can email <a href="mailto:support@flagsmith.com">support@flagsmith.com</a>.
+
+## Useful links
+
+[Website](https://www.flagsmith.com/)
+
+[Documentation](https://docs.flagsmith.com/)

--- a/lib/react-native-flagsmith/package.json
+++ b/lib/react-native-flagsmith/package.json
@@ -2,32 +2,7 @@
   "name": "react-native-flagsmith",
   "version": "8.1.0",
   "description": "Feature flagging to support continuous development",
-  "main": "./index.cjs.js",
-  "module": "./index.es.js",
-  "browser": "./index.umd.js",
-  "types": "./index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./index.es.js",
-      "require": "./index.cjs.js",
-      "browser": "./index.umd.js"
-    },
-    "./isomorphic": {
-      "import": "./isomorphic.es.js",
-      "require": "./isomorphic.cjs.js",
-      "browser": "./isomorphic.umd.js"
-    },
-    "./react": {
-      "import": "./react.es.js",
-      "require": "./react.cjs.js",
-      "browser": "./react.umd.js"
-    },
-    "./next-middleware": {
-      "import": "./next-middleware.es.js",
-      "require": "./next-middleware.cjs.js",
-      "browser": "./next-middleware.umd.js"
-    }
-  },
+  "main": "./index.es.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/Flagsmith/flagsmith-js-client/"
@@ -41,8 +16,9 @@
   "bugs": {
     "url": "https://github.com/Flagsmith/flagsmith-js-client/issues"
   },
+  "homepage": "https://flagsmith.com",
   "peerDependencies": {
     "react-native": ">=0.20.0"
   },
-  "homepage": "https://flagsmith.com"
+  "types": "./index.d.ts"
 }

--- a/lib/react-native-flagsmith/package.json
+++ b/lib/react-native-flagsmith/package.json
@@ -1,25 +1,48 @@
 {
   "name": "react-native-flagsmith",
-  "version": "8.0.2",
+  "version": "8.1.0",
   "description": "Feature flagging to support continuous development",
-  "main": "./index.js",
+  "main": "./index.cjs.js",
+  "module": "./index.es.js",
+  "browser": "./index.umd.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./index.es.js",
+      "require": "./index.cjs.js",
+      "browser": "./index.umd.js"
+    },
+    "./isomorphic": {
+      "import": "./isomorphic.es.js",
+      "require": "./isomorphic.cjs.js",
+      "browser": "./isomorphic.umd.js"
+    },
+    "./react": {
+      "import": "./react.es.js",
+      "require": "./react.cjs.js",
+      "browser": "./react.umd.js"
+    },
+    "./next-middleware": {
+      "import": "./next-middleware.es.js",
+      "require": "./next-middleware.cjs.js",
+      "browser": "./next-middleware.umd.js"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Flagsmith/flagsmith-js-client/"
   },
   "keywords": [
-    "react native",
     "feature flagger",
     "continuous deployment"
   ],
-  "author": "SSG",
+  "author": "Flagsmith",
   "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/Flagsmith/flagsmith-js-client/issues"
   },
-  "homepage": "https://flagsmith.com",
   "peerDependencies": {
     "react-native": ">=0.20.0"
   },
-  "types": "./index.d.ts"
+  "homepage": "https://flagsmith.com"
 }

--- a/move-react.js
+++ b/move-react.js
@@ -17,22 +17,12 @@ fs.copyFileSync(path.join(__dirname,"react.tsx"),path.join(__dirname,"lib/flagsm
 fs.copyFileSync(path.join(__dirname,"react.tsx"),path.join(__dirname,"lib/react-native-flagsmith/src/react.tsx"))
 fs.copyFileSync(path.join(__dirname,"react.d.ts"),path.join(__dirname,"lib/react-native-flagsmith/react.d.ts"))
 fs.copyFileSync(path.join(__dirname,"react.d.ts"),path.join(__dirname,"lib/flagsmith/react.d.ts"))
-fs.copyFileSync(path.join(__dirname,"react.d.ts"),path.join(__dirname,"lib/flagsmith-es/react.d.ts"))
 fs.copyFileSync(path.join(__dirname,"index.d.ts"),path.join(__dirname,"lib/react-native-flagsmith/index.d.ts"))
 fs.copyFileSync(path.join(__dirname,"index.d.ts"),path.join(__dirname,"lib/flagsmith/index.d.ts"))
-fs.copyFileSync(path.join(__dirname,"index.d.ts"),path.join(__dirname,"lib/flagsmith-es/index.d.ts"))
 
 // Copy source files to lib/react-native-flagsmith/src
 fs.copyFileSync(path.join(__dirname,"index.react-native.ts"),path.join(__dirname,"lib/react-native-flagsmith/src/index.react-native.ts"))
 fs.copyFileSync(path.join(__dirname,"flagsmith-core.ts"),path.join(__dirname,"lib/react-native-flagsmith/src/flagsmith-core.ts"))
-
-// fix flagsmith es sourcemap
-fs.copyFileSync(path.join(__dirname,"index-es.ts"),path.join(__dirname,"lib/flagsmith-es/src/index-es.ts"))
-fs.copyFileSync(path.join(__dirname,"flagsmith-core.ts"),path.join(__dirname,"lib/flagsmith-es/src/flagsmith-core.ts"))
-fs.copyFileSync(path.join(__dirname,"isomorphic-es.ts"),path.join(__dirname,"lib/flagsmith-es/src/isomorphic-es.ts"))
-
-
-
 
 const files= fs.readdirSync(path.join(__dirname, "lib/flagsmith"));
 files.forEach((fileName)=>{
@@ -42,63 +32,13 @@ files.forEach((fileName)=>{
     }
 })
 
-// fix paths in flagsmith/index.js sourcemaps
-replaceInFileSync(path.join(__dirname, "lib/flagsmith/index.js.map"),"../../../flagsmith-core.ts","./src/flagsmith-core.ts"  )
-replaceInFileSync(path.join(__dirname, "lib/flagsmith/index.js.map"),"../../../index.ts","./src/index.ts"  )
-replaceInFileSync(path.join(__dirname, "lib/flagsmith/index.js.map"),"../../../utils","./src/utils"  )
-replaceInFileSync(path.join(__dirname, "lib/flagsmith-es/index.js.map"),"../../../utils","./src/utils"  )
-replaceInFileSync(path.join(__dirname, "lib/react-native-flagsmith/index.js.map"),"../../../utils","./src/utils"  )
-replaceInFileSync(path.join(__dirname, "lib/flagsmith/react.js.map"),"../../../utils","./src/utils"  )
-replaceInFileSync(path.join(__dirname, "lib/flagsmith-es/react.js.map"),"../../../utils","./src/utils"  )
-replaceInFileSync(path.join(__dirname, "lib/react-native-flagsmith/react.js.map"),"../../../utils","./src/utils"  )
-
-// fix paths in flagsmith-es/index.js sourcemaps
-replaceInFileSync(path.join(__dirname, "lib/flagsmith-es/index.js.map"),"../../../flagsmith-core.ts","./src/flagsmith-core.ts"  )
-replaceInFileSync(path.join(__dirname, "lib/flagsmith-es/index.js.map"),"../../../index-es.ts","./src/index-es.ts"  )
-
-// fix paths in flagsmith/next-middleware.js sourcemaps
-replaceInFileSync(path.join(__dirname, "lib/flagsmith/next-middleware.js.map"),"../../../flagsmith-core.ts","./src/flagsmith-core.ts"  )
-replaceInFileSync(path.join(__dirname, "lib/flagsmith/next-middleware.js.map"),"../../../next-middleware.ts","./src/next-middleware.ts"  )
-
-// fix paths in flagsmith-es/next-middleware.js sourcemaps
-replaceInFileSync(path.join(__dirname, "lib/flagsmith-es/next-middleware.js.map"),"../../../flagsmith-core.ts","./src/flagsmith-core.ts"  )
-replaceInFileSync(path.join(__dirname, "lib/flagsmith-es/next-middleware.js.map"),"../../../next-middleware.ts","./src/next-middleware.ts"  )
-
-// fix paths in flagsmith/isomorphic.js sourcemaps
-replaceInFileSync(path.join(__dirname, "lib/flagsmith/isomorphic.js.map"),"../../../flagsmith-core.ts","./src/flagsmith-core.ts"  )
-replaceInFileSync(path.join(__dirname, "lib/flagsmith/isomorphic.js.map"),"../../../isomorphic.ts","./src/isomorphic.ts"  )
-
-// fix paths in flagsmith-es/isomorphic.js sourcemaps
-replaceInFileSync(path.join(__dirname, "lib/flagsmith-es/isomorphic.js.map"),"../../../flagsmith-core.ts","./src/flagsmith-core.ts"  )
-replaceInFileSync(path.join(__dirname, "lib/flagsmith-es/isomorphic.js.map"),"../../../isomorphic-es.ts","./src/isomorphic-es.ts"  )
-
-// fix paths in react-native-flagsmith/index.js sourcemaps
-replaceInFileSync(path.join(__dirname, "lib/react-native-flagsmith/index.js.map"),"../../../flagsmith-core.ts","./src/flagsmith-core.ts"  )
-replaceInFileSync(path.join(__dirname, "lib/react-native-flagsmith/index.js.map"),"../../index.react-native.ts","./src/index.react-native.ts"  )
-
-
-// fix paths in flagsmith/react.js sourcemaps
-replaceInFileSync(path.join(__dirname, "lib/flagsmith/react.js.map"),"../../../react.tsx","./src/react.tsx"  )
-replaceInFileSync(path.join(__dirname, "lib/react-native-flagsmith/react.js.map"),"../../../react.tsx","./src/react.tsx"  )
-
-// fix paths in flagsmith-es/react.js sourcemaps
-replaceInFileSync(path.join(__dirname, "lib/flagsmith-es/react.js.map"),"../../../react.tsx","./src/react.tsx"  )
-
-
 // copy types.d
 fs.copyFileSync(path.join(__dirname,"types.d.ts"),path.join(__dirname,"lib/flagsmith/src/types.d.ts"))
-fs.copyFileSync(path.join(__dirname,"types.d.ts"),path.join(__dirname,"lib/flagsmith-es/src/types.d.ts"))
 fs.copyFileSync(path.join(__dirname,"types.d.ts"),path.join(__dirname,"lib/react-native-flagsmith/src/types.d.ts"))
 
 fs.copyFileSync(path.join(__dirname,"types.d.ts"),path.join(__dirname,"lib/flagsmith/types.d.ts"))
-fs.copyFileSync(path.join(__dirname,"types.d.ts"),path.join(__dirname,"lib/flagsmith-es/types.d.ts"))
 fs.copyFileSync(path.join(__dirname,"types.d.ts"),path.join(__dirname,"lib/react-native-flagsmith/types.d.ts"))
 
-
-//Rollup can't ignore lib d.ts files
-try {
-    fs.rmdirSync(path.join(__dirname,"lib/flagsmith-es/lib"), {recursive:true})
-} catch (e){}
 try {
     fs.rmdirSync(path.join(__dirname,"lib/flagsmith/lib"), {recursive:true})
 } catch (e){}
@@ -109,9 +49,6 @@ try {
 
 try {
     fs.rmdirSync(path.join(__dirname,"lib/flagsmith/test"), {recursive:true})
-} catch (e){}
-try {
-    fs.rmdirSync(path.join(__dirname,"lib/flagsmith-es/test"), {recursive:true})
 } catch (e){}
 try {
     fs.rmdirSync(path.join(__dirname,"lib/react-native-flagsmith/test"), {recursive:true})
@@ -143,5 +80,4 @@ function syncFolders(src, dest) {
 }
 
 syncFolders(path.join(__dirname,'utils'),path.join(__dirname,'lib/flagsmith/src/utils'))
-syncFolders(path.join(__dirname,'utils'),path.join(__dirname,'lib/flagsmith-es/src/utils'))
 syncFolders(path.join(__dirname,'utils'),path.join(__dirname,'lib/react-native-flagsmith/src/utils'))

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,16 +22,14 @@ const sourcemapPathTransform = (relativeSourcePath) => {
     if(relativeSourcePath.includes("node_modules")) {
         return relativeSourcePath
     }
-    console.log(relativeSourcePath)
     return relativeSourcePath.replace("../../../", "./src/");
 }
 
 const generateConfig = (input, outputDir, name, exclude = []) => ({
     input,
     output: [
-        { file: path.join(outputDir, `${name}.umd.js`), format: "umd", name, sourcemap: true,sourcemapPathTransform },
+        { file: path.join(outputDir, `${name}.js`), format: "umd", name, sourcemap: true,sourcemapPathTransform },
         { file: path.join(outputDir, `${name}.es.js`), format: "es", sourcemap: true, sourcemapPathTransform },
-        { file: path.join(outputDir, `${name}.cjs.js`), format: "cjs", sourcemap: true, sourcemapPathTransform },
     ],
     plugins: createPlugins(exclude),
     external: externalDependencies,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,233 +1,47 @@
-import resolve, { nodeResolve } from '@rollup/plugin-node-resolve';
+import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import typescript from '@rollup/plugin-typescript';
 import { terser } from 'rollup-plugin-terser';
 import peerDepsExternal from 'rollup-plugin-peer-deps-external';
 import path from 'path';
-import * as react from 'react';
-import * as reactDom from 'react-dom';
 
-const packageJson = require("./package.json");
-const plugins = (exclude)=>[
+const externalDependencies = ["react", "react-dom", "react-native"];
+
+const createPlugins = (exclude) => [
     peerDepsExternal(),
-    nodeResolve(),
     resolve(),
-    commonjs({
-        namedExports: {
-            react: Object.keys(react),
-            'react-dom': Object.keys(reactDom)
-        }
-    }),
-    typescript({ tsconfig: "./tsconfig.json",exclude }),
+    commonjs(),
+    typescript({ tsconfig: "./tsconfig.json", exclude }),
     terser({
         format: {
-            comments: false
+            comments: false,
         },
     }),
 ];
-
-const pluginsES = (exclude)=>[
-    peerDepsExternal(),
-    nodeResolve(),
-    resolve(),
-    commonjs({
-        namedExports: {
-            react: Object.keys(react),
-            'react-dom': Object.keys(reactDom)
-        }
-    }),
-    typescript({ tsconfig: "./tsconfig.json",exclude }),
-    terser({
-        format: {
-            comments: false
-        },
-    }),
-];
-
-const generateES = (config, filePath, _plugins, input) => {
-    return {
-        ...config,
-        input,
-        plugins: pluginsES(_plugins),
-        output: [
-            {
-                ...config.output[0],
-                file: filePath,
-                format: 'es'
-            }
-        ]
+const sourcemapPathTransform = (relativeSourcePath) => {
+    if(relativeSourcePath.includes("node_modules")) {
+        return relativeSourcePath
     }
+    console.log(relativeSourcePath)
+    return relativeSourcePath.replace("../../../", "./src/");
 }
 
-const webModule = {
-    input: './index.ts',
+const generateConfig = (input, outputDir, name, exclude = []) => ({
+    input,
     output: [
-        {
-            file: path.join(__dirname, 'lib/flagsmith/index.js'),
-            format: "umd",
-            name:"flagsmith",
-            sourcemap: true,
-        },
+        { file: path.join(outputDir, `${name}.umd.js`), format: "umd", name, sourcemap: true,sourcemapPathTransform },
+        { file: path.join(outputDir, `${name}.es.js`), format: "es", sourcemap: true, sourcemapPathTransform },
+        { file: path.join(outputDir, `${name}.cjs.js`), format: "cjs", sourcemap: true, sourcemapPathTransform },
     ],
-    plugins: plugins(
-        [
-            "./react.tsx",
-            "./isomorphic.ts",
-            "./next-middleware.ts",
-            "./index.react-native.ts",
-        ]
-    ),
-    external: ["react", "react-dom"]
-}
-//
-const webES = generateES(
-    webModule,
-    path.join(__dirname, 'lib/flagsmith-es/index.js'),
-    [
-        "./react.tsx",
-        "./isomorphic.ts",
-        "./index.react-native.ts",
-    ],
-    './index-es.ts',
-)
+    plugins: createPlugins(exclude),
+    external: externalDependencies,
+});
 
-
-
-const isomorphicModule =  {
-    input: './isomorphic.ts',
-    output: [
-        {
-            file: path.join(__dirname, 'lib/flagsmith/isomorphic.js'),
-            format: "umd",
-            name:"isomorphic",
-            sourcemap: true,
-        },
-    ],
-    plugins: plugins(
-        [
-            "./react/index.ts",
-            "./index.react-native.ts",
-        ]
-    ),
-    external: ["react", "react-dom"]
-};
-
-const isomorphicES = generateES(
-    isomorphicModule,
-    path.join(__dirname, 'lib/flagsmith-es/isomorphic.js'),
-    [
-        "./react/index.ts",
-        "./index.react-native.ts",
-    ],
-    './isomorphic-es.ts',
-
-)
-
-const nextModule =  {
-    input: './next-middleware.ts',
-    output: [
-        {
-            file: path.join(__dirname, 'lib/flagsmith/next-middleware.js'),
-            format: "umd",
-            name:"next-middleware",
-            sourcemap: true,
-        },
-    ],
-    plugins: plugins(
-        [
-            "./react.tsx",
-            "./index.react-native.ts",
-        ]
-    ),
-    external: ["react", "react-dom"]
-};
-
-const nextES = generateES(
-    nextModule,
-    path.join(__dirname, 'lib/flagsmith-es/next-middleware.js'),
-    [
-        "./react.tsx",
-        "./index.react-native.ts",
-    ],
-    './next-middleware.ts',
-
-)
-
-const reactModule =     {
-    input: './react.tsx',
-    output: [
-        {
-            file: path.join(__dirname, 'lib/flagsmith/react.js'),
-            format: "umd",
-            name:"flagsmith-react",
-            sourcemap: true,
-        },
-    ],
-    plugins: plugins(
-        [
-            "./index.ts",
-            "./types.ts",
-            "./isomorphic.ts",
-            "./index.react-native.ts",
-        ]
-    ),
-    external: ["react", "react-dom"]
-}
-
-const reactReactNativeModule =     {
-    input: './react.tsx',
-    output: [
-        {
-            file: path.join(__dirname, 'lib/react-native-flagsmith/react.js'),
-            format: "umd",
-            name:"react-native-flagsmith-react",
-            sourcemap: true,
-        },
-    ],
-    plugins: plugins(
-        [
-            "./index.ts",
-            "./types.ts",
-            "./isomorphic.ts",
-            "./index.react-native.ts",
-        ]
-    ),
-    external: ["react", "react-dom"]
-}
-
-const reactModuleES = generateES(
-    reactModule,
-    path.join(__dirname, 'lib/flagsmith-es/react.js'),
-    [
-        "./index.ts",
-        "./types.ts",
-        "./isomorphic.ts",
-        "./index.react-native.ts",
-    ],
-    reactModule.input
-)
-
-
-export default [webModule, reactModule,
-    isomorphicModule,isomorphicES, nextModule, nextES, webES, reactReactNativeModule,  reactModuleES
-].concat([
-    {
-        input: './index.react-native.ts',
-        output: [
-            {
-                file: path.join(__dirname, '/lib/react-native-flagsmith/index.js'),
-                format: "umd",
-                name:"react-native-flagsmith",
-                sourcemap: true,
-            },
-        ],
-        plugins: plugins(
-            [
-                "./react/**",
-                "./isomorphic.ts",
-                "./index.react-native.ts",
-            ]
-        ),
-        external: ["react", "react-dom", "react-native"]
-    },
-])
+export default [
+    generateConfig('./index.ts', './lib/flagsmith', 'index', ['./react.tsx', './isomorphic.ts', './index.react-native.ts']),
+    generateConfig('./isomorphic.ts', './lib/flagsmith', 'isomorphic', ['./react/index.ts', './index.react-native.ts']),
+    generateConfig('./next-middleware.ts', './lib/flagsmith', 'next-middleware', ['./react.tsx', './index.react-native.ts']),
+    generateConfig('./react.tsx', './lib/flagsmith', 'react', ['./index.ts', './types.ts', './isomorphic.ts', './index.react-native.ts']),
+    generateConfig('./react.tsx', './lib/react-native-flagsmith', 'react', ['./index.ts', './types.ts', './isomorphic.ts', './index.react-native.ts']),
+    generateConfig('./index.react-native.ts', './lib/react-native-flagsmith', 'index', ['./react/**', './isomorphic.ts', './index.react-native.ts']),
+];

--- a/test/react.test.tsx
+++ b/test/react.test.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 // @ts-ignore
-import { FlagsmithProvider, useFlags, useFlagsmithLoading } from '../lib/flagsmith/react.cjs.js';
+import { FlagsmithProvider, useFlags, useFlagsmithLoading } from '../lib/flagsmith/react';
 import {
     defaultState,
     delay,

--- a/test/react.test.tsx
+++ b/test/react.test.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import { FlagsmithProvider, useFlags, useFlagsmithLoading } from '../lib/flagsmith/react';
+// @ts-ignore
+import { FlagsmithProvider, useFlags, useFlagsmithLoading } from '../lib/flagsmith/react.cjs.js';
 import {
     defaultState,
     delay,


### PR DESCRIPTION
Prior to this PR, the flagsmith and flagsmith-es packages were separate, this makes the flagsmith sdk both UMD and ES.

This release will log a deprecated notice to flagsmith-es preinstall, following this release there will be no more versions of Flagsmith-es.