### PR TITLE
chore: Deprecate flagsmith-es

### DIFF
--- a/lib/flagsmith-es/README.md
+++ b/lib/flagsmith-es/README.md
@@ -1,0 +1,5 @@
+<img width="100%" src="https://github.com/Flagsmith/flagsmith/raw/main/static-files/hero.png"/>
+
+# Flagsmith ESM Javascript Client
+
+This module is now deprecated and bundled into the [Flagsmith JS Client](https://www.npmjs.com/package/flagsmith).

--- a/lib/flagsmith-es/package-lock.json
+++ b/lib/flagsmith-es/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "flagsmith-es",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "flagsmith-es",
-      "version": "8.0.2",
+      "version": "8.0.3",
+      "hasInstallScript": true,
       "license": "BSD-3-Clause"
     }
   }

--- a/lib/flagsmith-es/package.json
+++ b/lib/flagsmith-es/package.json
@@ -5,7 +5,7 @@
   "main": "./index.js",
   "type": "module",
   "scripts": {
-    "postinstall": "echo '\u001b[31m\u001b[1mimportant: flagsmith-es is deprecated\u001b[0m\n\nplease install the official flagsmith package instead:\n\n  \u001b[32m\u001b[1mnpm install flagsmith\u001b[0m\n\nfor more details, visit: https://github.com/Flagsmith/flagsmith-js-client\n' && exit 1"
+    "postinstall": "echo '\u001b[31m\u001b[1mimportant: flagsmith-es is deprecated\u001b[0m\n\nplease install the official flagsmith package instead:\n\n  \u001b[32m\u001b[1mnpm install flagsmith\u001b[0m\n\nfor more details, visit: https://github.com/Flagsmith/flagsmith-js-client\n'"
   },
   "repository": {
     "type": "git",

--- a/lib/flagsmith-es/package.json
+++ b/lib/flagsmith-es/package.json
@@ -1,9 +1,12 @@
 {
   "name": "flagsmith-es",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "description": "Feature flagging to support continuous development. This is an esm equivalent of the standard flagsmith npm module.",
   "main": "./index.js",
   "type": "module",
+  "scripts": {
+    "postinstall": "echo '\u001b[31m\u001b[1mimportant: flagsmith-es is deprecated\u001b[0m\n\nplease install the official flagsmith package instead:\n\n  \u001b[32m\u001b[1mnpm install flagsmith\u001b[0m\n\nfor more details, visit: https://github.com/Flagsmith/flagsmith-js-client\n' && exit 1"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Flagsmith/flagsmith-js-client"

--- a/lib/flagsmith/package.json
+++ b/lib/flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {

--- a/lib/react-native-flagsmith/package.json
+++ b/lib/react-native-flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flagsmith",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {


### PR DESCRIPTION
This adds a post-install deprecation notice to flagsmith-es, https://github.com/Flagsmith/flagsmith-js-client/pull/280 will make the package no longer necessary

![image](https://github.com/user-attachments/assets/a7624cb2-d473-4a8e-be9d-10c7e82caaf0)
