### PR TITLE
fix: Types not being exported and autocomplete not working

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 import { IFlagsmith } from './types';
 declare const flagsmith: IFlagsmith;
 export default flagsmith;
+export * from './types';
 export declare const createFlagsmithInstance: <
     F extends string = string,
     T extends string = string,

--- a/lib/flagsmith/package.json
+++ b/lib/flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "module": "./index.mjs",
@@ -10,22 +10,26 @@
     ".": {
       "import": "./index.mjs",
       "require": "./index.js",
-      "browser": "./index.js"
+      "browser": "./index.js",
+      "types": "./index.d.ts"
     },
     "./isomorphic": {
       "import": "./isomorphic.mjs",
       "require": "./isomorphic.js",
-      "browser": "./isomorphic.js"
+      "browser": "./isomorphic.js",
+      "types": "./isomorphic.d.ts"
     },
     "./react": {
       "import": "./react.mjs",
       "require": "./react.js",
-      "browser": "./react.js"
+      "browser": "./react.js",
+      "types": "./react.d.ts"
     },
     "./next-middleware": {
       "import": "./next-middleware.mjs",
       "require": "./next-middleware.js",
-      "browser": "./next-middleware.js"
+      "browser": "./next-middleware.js",
+      "types": "./next-middleware.d.ts"
     }
   },
   "repository": {

--- a/lib/react-native-flagsmith/package.json
+++ b/lib/react-native-flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flagsmith",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {

--- a/react.d.ts
+++ b/react.d.ts
@@ -1,10 +1,11 @@
 import React, { FC } from 'react';
-import { IFlagsmith, IFlagsmithTrait, IFlagsmithFeature, IState } from '../types';
+import { IFlagsmith, IFlagsmithTrait, IFlagsmithFeature, IState, LoadingState } from './types';
+export * from './types';
 export declare const FlagsmithContext: React.Context<IFlagsmith>;
 export declare type FlagsmithContextType<F extends string = string, T extends string = string> = {
     flagsmith: IFlagsmith<F, T>;
     options?: Parameters<IFlagsmith<F, T>['init']>[0];
-    serverState?: IState<F, T>;
+    serverState?: IState;
     children: React.ReactElement[] | React.ReactElement;
 };
 export declare const FlagsmithProvider: FC<FlagsmithContextType>;


### PR DESCRIPTION
This PR fixes the following problems:
- Autocomplete was not working
- Users were having issues with v9.0.0 (`Types are found in 'react.d.ts', but this result could not be resolved when respecting package.json "exports"`)
- `Cannot find module './evaluation-context' or its corresponding type declarations.` https://github.com/Flagsmith/flagsmith-js-client/issues/283