### PR TITLE
feat: (WIP) Support arbitrary analytics endpoint URLs

### DIFF
--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -257,4 +257,10 @@ describe('Flagsmith.init', () => {
         });
         expect(onError).toHaveBeenCalledWith(new Error('Mocked fetch error'));
     });
+    test('should resolve analytics URL, if not specified, relative to API URL', async () => {
+        const { flagsmith, initConfig } = getFlagsmith()
+        initConfig.api = 'https://flagsmith.example.com'
+        await flagsmith.init(initConfig)
+        expect(flagsmith.analyticsUrl).toEqual('https://flagsmith.example.com/analytics/flags/')
+    })
 });

--- a/types.d.ts
+++ b/types.d.ts
@@ -91,7 +91,18 @@ export declare type LoadingState = {
 export type OnChange<F extends string = string> = (previousFlags: IFlags<F> | null, params: IRetrieveInfo, loadingState:LoadingState) => void
 export interface IInitConfig<F extends string = string, T extends string = string> {
     AsyncStorage?: any;
+    /** Absolute and versioned URL of Flagsmith API to use, including a trailing slash.
+     * Defaults to {@link DEFAULT_API_URL}.
+     * @example "https://flagsmith.example.com/api/v1/
+     */
     api?: string;
+    /**
+     * Absolute or relative URL of the Flagsmith analytics events API endpoint. Use this if your analytics and flags API
+     * endpoints are on different domains, e.g. if you are fetching flags from an Edge Proxy.
+     * Defaults to {@link ANALYTICS_ENDPOINT} relative to {@link api}.
+     * @example "https://flagsmith.example.com/api/v1/analytics"
+     */
+    analyticsUrl?: string;
     evaluationContext?: ClientEvaluationContext;
     cacheFlags?: boolean;
     cacheOptions?: ICacheOptions;
@@ -270,9 +281,13 @@ export interface IFlagsmith<F extends string = string, T extends string = string
         loadStale: boolean;
     };
     /**
-     * Used internally, this is the api provided in flagsmith.init, defaults to our production API
+     * @see IInitConfig.api
      */
     api: string
+    /**
+     * @see IInitConfig.analyticsUrl
+     */
+    analyticsUrl: string
 }
 
 export {};


### PR DESCRIPTION
Similar to https://github.com/Flagsmith/flagsmith-nodejs-client/pull/168

Tests not passing because `Request` is not available when using `unfetch`, or possibly some other issue with the Jest configuration. I would strongly prefer removing `fetch` polyfills and sticking to native `fetch` for browsers and Node if feasible.