### PR TITLE
fix: evalation-context import, remove deprecation, add types import to…

### DIFF
--- a/lib/flagsmith/package.json
+++ b/lib/flagsmith/package.json
@@ -1,12 +1,17 @@
 {
   "name": "flagsmith",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "module": "./index.mjs",
   "browser": "./index.js",
   "types": "./index.d.ts",
   "exports": {
+    "./types": {
+      "import": "./types.d.ts",
+      "require": "./types.d.ts",
+      "browser": "./types.d.ts"
+    },
     ".": {
       "import": "./index.mjs",
       "require": "./index.js",

--- a/lib/react-native-flagsmith/package.json
+++ b/lib/react-native-flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flagsmith",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {

--- a/move-react.js
+++ b/move-react.js
@@ -29,9 +29,10 @@ files.forEach((fileName)=>{
 // copy types.d
 fs.copyFileSync(path.join(__dirname,"types.d.ts"),path.join(__dirname,"lib/flagsmith/src/types.d.ts"))
 fs.copyFileSync(path.join(__dirname,"types.d.ts"),path.join(__dirname,"lib/react-native-flagsmith/src/types.d.ts"))
+// copy evaluation-context
+fs.copyFileSync(path.join(__dirname,"evaluation-context.ts"),path.join(__dirname,"lib/flagsmith/evaluation-context.ts"))
+fs.copyFileSync(path.join(__dirname,"evaluation-context.ts"),path.join(__dirname,"lib/react-native-flagsmith/evaluation-context.ts"))
 
-fs.copyFileSync(path.join(__dirname,"types.d.ts"),path.join(__dirname,"lib/flagsmith/types.d.ts"))
-fs.copyFileSync(path.join(__dirname,"types.d.ts"),path.join(__dirname,"lib/react-native-flagsmith/types.d.ts"))
 
 try {
     fs.rmdirSync(path.join(__dirname,"lib/flagsmith/lib"), {recursive:true})

--- a/move-react.js
+++ b/move-react.js
@@ -26,10 +26,11 @@ files.forEach((fileName)=>{
     }
 })
 
-// copy types.d
+// copy types and evaluation-context
 fs.copyFileSync(path.join(__dirname,"types.d.ts"),path.join(__dirname,"lib/flagsmith/src/types.d.ts"))
 fs.copyFileSync(path.join(__dirname,"types.d.ts"),path.join(__dirname,"lib/react-native-flagsmith/src/types.d.ts"))
-// copy evaluation-context
+fs.copyFileSync(path.join(__dirname,"types.d.ts"),path.join(__dirname,"lib/flagsmith/types.d.ts"))
+fs.copyFileSync(path.join(__dirname,"types.d.ts"),path.join(__dirname,"lib/react-native-flagsmith/types.d.ts"))
 fs.copyFileSync(path.join(__dirname,"evaluation-context.ts"),path.join(__dirname,"lib/flagsmith/evaluation-context.ts"))
 fs.copyFileSync(path.join(__dirname,"evaluation-context.ts"),path.join(__dirname,"lib/react-native-flagsmith/evaluation-context.ts"))
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -104,18 +104,9 @@ export interface IInitConfig<F extends string = string, T extends string = strin
     enableDynatrace?: boolean;
     enableLogs?: boolean;
     angularHttpClient?: any;
-    /**
-     * * @deprecated Please consider using evaluationContext.identity: {@link IInitConfig.evaluationContext}.
-     * */
     environmentID?: string;
     headers?: object;
-    /**
-     * * @deprecated Please consider using evaluationContext.identity: {@link IInitConfig.evaluationContext}.
-     * */
     identity?: IIdentity;
-    /**
-     * * @deprecated Please consider using evaluationContext.identity: {@link IInitConfig.evaluationContext}.
-     * */
     traits?: ITraits<T>;
     onChange?: OnChange<F>;
     onError?: (err: Error) => void;
@@ -240,8 +231,8 @@ export interface IFlagsmith<F extends string = string, T extends string = string
      */
     setTraits: (traits: ITraits) => Promise<void>;
     /**
-     * * @deprecated Please consider using evaluationContext.identity: {@link IFlagsmith.getContext}.
-     * */
+     * The stored identity of the user
+    */
     identity?: IIdentity;
     /**
      * Whether the flagsmith SDK is initialised


### PR DESCRIPTION
- added evaluation-context.ts to bundle since it is imported in types.d.ts
- Removes missed deprecation
- Adds types to package.json imports to allow for backwards compatibility, without this we get 

```
import { IFlags, IRetrieveInfo, LoadingState } from 'flagsmith/types';
TS2307: Cannot find module flagsmith/types or its corresponding type declarations.
```