### PR TITLE
fix: Handle API URL with or without trailing slash

### DIFF
--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -23,7 +23,7 @@ import angularFetch from './utils/angular-fetch';
 import setDynatraceValue from './utils/set-dynatrace-value';
 import { EvaluationContext } from './evaluation-context';
 import { isTraitEvaluationContext, toEvaluationContext, toTraitEvaluationContextObject } from './utils/types';
-import { ensureTrailingSlash } from "./utils/ensureTrailingSlash";
+import { ensureTrailingSlash } from './utils/ensureTrailingSlash';
 
 enum FlagSource {
     "NONE" = "NONE",

--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -23,7 +23,7 @@ import angularFetch from './utils/angular-fetch';
 import setDynatraceValue from './utils/set-dynatrace-value';
 import { EvaluationContext } from './evaluation-context';
 import { isTraitEvaluationContext, toEvaluationContext, toTraitEvaluationContextObject } from './utils/types';
-import {ensureTrailingSlash} from "./utils/ensureTrailingSlash";
+import { ensureTrailingSlash } from "./utils/ensureTrailingSlash";
 
 enum FlagSource {
     "NONE" = "NONE",

--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -23,6 +23,7 @@ import angularFetch from './utils/angular-fetch';
 import setDynatraceValue from './utils/set-dynatrace-value';
 import { EvaluationContext } from './evaluation-context';
 import { isTraitEvaluationContext, toEvaluationContext, toTraitEvaluationContextObject } from './utils/types';
+import {ensureTrailingSlash} from "./utils/ensureTrailingSlash";
 
 enum FlagSource {
     "NONE" = "NONE",
@@ -318,7 +319,7 @@ const Flagsmith = class {
                 ) : {},
             } : evaluationContext.identity;
             this.evaluationContext = evaluationContext;
-            this.api = api;
+            this.api = ensureTrailingSlash(api);
             this.headers = headers;
             this.getFlagInterval = null;
             this.analyticsInterval = null;

--- a/lib/flagsmith/package.json
+++ b/lib/flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "module": "./index.mjs",

--- a/lib/react-native-flagsmith/package.json
+++ b/lib/react-native-flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flagsmith",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -96,6 +96,21 @@ describe('Flagsmith.init', () => {
         });
         await expect(flagsmith.init(initConfig)).rejects.toThrow(Error);
     });
+    test('should sanitise api url', async () => {
+        const onChange = jest.fn();
+        const { flagsmith,initConfig } = getFlagsmith({
+            api:'https://edge.api.flagsmith.com/api/v1/',
+            onChange,
+        });
+        await flagsmith.init(initConfig)
+        expect(flagsmith.getState().api).toBe('https://edge.api.flagsmith.com/api/v1/');
+        const { flagsmith:flagsmith2 } = getFlagsmith({
+            api:'https://edge.api.flagsmith.com/api/v1',
+            onChange,
+        });
+        await flagsmith2.init(initConfig)
+        expect(flagsmith2.getState().api).toBe('https://edge.api.flagsmith.com/api/v1/');
+    });
     test('should reject initialize with identity bad key', async () => {
         const onChange = jest.fn();
         const { flagsmith, initConfig, mockFetch } = getFlagsmith({ onChange, environmentID: 'bad' });

--- a/utils/ensureTrailingSlash.ts
+++ b/utils/ensureTrailingSlash.ts
@@ -1,3 +1,3 @@
 export function ensureTrailingSlash(str: string): string {
-    return str.replace(/\/+$/, '') + '/';
+    return str.endsWith('/') ? str : str + '/';
 }

--- a/utils/ensureTrailingSlash.ts
+++ b/utils/ensureTrailingSlash.ts
@@ -1,0 +1,3 @@
+export function ensureTrailingSlash(str: string): string {
+    return str.replace(/\/+$/, '') + '/';
+}


### PR DESCRIPTION
Ensures that the flagsmith base url has a single trailing /. Whilst I considered using JavaScript's built in URL API, there's a chance that a polyfil would be needed to guarantee exact same behaviour so this seemed far less risky.