### PR TITLE
fix: exports isomorphic type definitions

### DIFF
--- a/lib/flagsmith/package.json
+++ b/lib/flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "module": "./index.mjs",


### PR DESCRIPTION
Fixes: [#289](https://github.com/Flagsmith/flagsmith-js-client/issues/289)
- This PR includes a version bump from `9.0.3` to `9.0.4`.
- Exports correct isomorphic type definitions in  [`lib/flagsmith/package.json`](diffhunk://#diff-964abcf7c6b90d80a9d73ba3a6fbd4b7d176f05d3695ebcb8c4a0af7d4094fe3L3-R3): Updated the version from `9.0.3` to `9.0.4`.