### PR TITLE
fix: conflicting ts field type

### DIFF
--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -261,7 +261,7 @@ const Flagsmith = class {
     analyticsInterval: NodeJS.Timer | null= null
     api: string|null= null
     cacheFlags= false
-    ts: number|null= null
+    ts?: number
     enableAnalytics= false
     enableLogs= false
     evaluationContext: EvaluationContext= {}

--- a/lib/flagsmith/package.json
+++ b/lib/flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith",
-  "version": "9.0.4",
+  "version": "9.0.5",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "module": "./index.mjs",

--- a/lib/react-native-flagsmith/package.json
+++ b/lib/react-native-flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flagsmith",
-  "version": "9.0.4",
+  "version": "9.0.5",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {


### PR DESCRIPTION
Fix ts class field conflicting type definitions

This was causing issues when defining `flagsmith.json` type to IState as reported in #292 