### PR TITLE
Fix: typo in type definition file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ For full documentation visit [https://docs.flagsmith.com/clients/javascript/](ht
 
 Please read [CONTRIBUTING.md](https://gist.github.com/kyle-ssg/c36a03aebe492e45cbd3eefb21cb0486) for details on our code of conduct, and the process for submitting pull requests to us.
 
+### Development
+
+1. Install Node >= v14.4
+1. Clone the repo
+1. Install dependencies: `npm install`
+1. Generate files: `npm run build`
+1. Make your code changes
+1. Ensure the project builds with `npm run build` and all tests are passing with `npm run test` before submitting a pull request
+
 ## Getting Help
 
 If you encounter a bug or feature request we would like to hear about it. Before you submit an issue please search existing issues in order to prevent duplicates. 

--- a/lib/flagsmith/package.json
+++ b/lib/flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "module": "./index.mjs",

--- a/lib/react-native-flagsmith/package.json
+++ b/lib/react-native-flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flagsmith",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "generatetypes": "curl https://raw.githubusercontent.com/Flagsmith/flagsmith/refs/heads/main/sdk/evaluation-context.json -o evaluation-context.json && npx quicktype -o evaluation-context.ts --src-lang schema --just-types --no-prefer-types --nice-property-names evaluation-context.json && rm evaluation-context.json",
     "postinstall": "patch-package",
     "prepublish": "npx in-publish && npm run build || echo",
-    "test": "jest --env=jsdom"
+    "test": "jest --env=jsdom",
+    "checknodeversion": "npx ls-engines"
   },
   "repository": {
     "type": "git",
@@ -79,5 +80,8 @@
     "react-native-sse": "^1.1.0",
     "reconnecting-eventsource": "^1.5.0"
   },
-  "types": "./index.d.ts"
+  "types": "./index.d.ts",
+  "engines": {
+    "node": ">= 14.14"
+  }
 }

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -5,7 +5,7 @@ import {IFlagsmith} from '../types';
 describe('Flagsmith Types', () => {
 
     // The following tests will fail to compile if any of the types fail / expect-error has no type issues
-    // Therefor all of the following ts-expect-errors and eslint-disable-lines are by design
+    // Therefore all of the following ts-expect-errors and eslint-disable-lines are intentional
     test('should allow supplying string generics to a flagsmith instance', async () => {
         const { flagsmith,  } = getFlagsmith({ });
         const typedFlagsmith = flagsmith as IFlagsmith<"flag1"|"flag2">

--- a/types.d.ts
+++ b/types.d.ts
@@ -10,7 +10,7 @@ export type DynatraceObject = {
 }
 
 export interface IFlagsmithFeature<Value = IFlagsmithValue> {
-    id: numbers
+    id: number;
     enabled: boolean;
     value: Value;
 }


### PR DESCRIPTION
Closes https://github.com/Flagsmith/flagsmith-js-client/issues/307

- fix typos in type definition file and test file
- add development details to readme and `package.json`