### PR TITLE
fix: updated-interface-flags-for-javascript-client

### DIFF
--- a/lib/flagsmith/package.json
+++ b/lib/flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "module": "./index.mjs",

--- a/lib/react-native-flagsmith/package.json
+++ b/lib/react-native-flagsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flagsmith",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Feature flagging to support continuous development",
   "main": "./index.js",
   "repository": {

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -1,6 +1,6 @@
 // Sample test
 import {getFlagsmith} from './test-constants';
-import {IFlagsmith} from '../types';
+import {IFlagsmith, IFlagsmithFeature} from '../types';
 
 describe('Flagsmith Types', () => {
 
@@ -20,13 +20,45 @@ describe('Flagsmith Types', () => {
         typedFlagsmith.getValue("flag2")
     });
     test('should allow supplying interface generics to a flagsmith instance', async () => {
-        const { flagsmith,  } = getFlagsmith({ });
+        const { flagsmith } = getFlagsmith({});
         const typedFlagsmith = flagsmith as IFlagsmith<
             {
                 stringFlag: string
                 numberFlag: number
                 objectFlag: { first_name: string }
             }>
+        typedFlagsmith.init({
+            environmentID: "test",
+            defaultFlags: {
+                stringFlag: {
+                    id: 1,
+                    enabled: true,
+                    value: "string_value"
+                },
+                numberFlag: {
+                    id: 2,
+                    enabled: true,
+                    value: 123
+                },
+                objectFlag: {
+                    id: 3,
+                    enabled: true,
+                    value: JSON.stringify({ first_name: "John" })
+                }
+            },
+            onChange: (previousFlags) => {
+                //eslint-disable-next-line @typescript-eslint/no-unused-vars
+                const previousStringFlag = previousFlags?.stringFlag
+                //eslint-disable-next-line @typescript-eslint/no-unused-vars
+                const previousNumberFlag = previousFlags?.numberFlag
+                //eslint-disable-next-line @typescript-eslint/no-unused-vars
+                const previousObjectFlag = previousFlags?.objectFlag
+                //@ts-expect-error - flag does not exist
+                //eslint-disable-next-line @typescript-eslint/no-unused-vars
+                const previousNonExistingFlag = previousFlags?.nonExistingFlag
+            }
+        })
+
         //@ts-expect-error - feature not defined
         typedFlagsmith.hasFeature("fail")
         //@ts-expect-error - feature not defined
@@ -36,6 +68,18 @@ describe('Flagsmith Types', () => {
         typedFlagsmith.hasFeature("numberFlag")
         typedFlagsmith.getValue("stringFlag")
         typedFlagsmith.getValue("numberFlag")
+        
+        const typedFlags = await typedFlagsmith.getAllFlags()
+        //eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const asString = typedFlags.stringFlag
+        //eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const asNumber = typedFlags.numberFlag
+        //eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const asObject = typedFlags.objectFlag
+
+        // @ts-expect-error - invalid does not exist on type
+        //eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const asNonExisting = typedFlags.nonExistingFlag
 
         //eslint-disable-next-line @typescript-eslint/no-unused-vars
         const stringFlag: string | null = typedFlagsmith.getValue("stringFlag")
@@ -44,7 +88,7 @@ describe('Flagsmith Types', () => {
         //eslint-disable-next-line @typescript-eslint/no-unused-vars
         const firstName: string | undefined = typedFlagsmith.getValue("objectFlag")?.first_name
 
-        // @ts-expect-error - invalid does not exist on type announcement
+        // @ts-expect-error - invalid does not exist on type
         //eslint-disable-next-line @typescript-eslint/no-unused-vars
         const invalidPointer: string = typedFlagsmith.getValue("objectFlag")?.invalid
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -96,7 +96,7 @@ export type ApplicationMetadata = {
     version?: string;
 }
 
-export interface IInitConfig<F extends string = string, T extends string = string> {
+export interface IInitConfig<F extends string | Record<string, any> = string, T extends string = string> {
     AsyncStorage?: any;
     api?: string;
     evaluationContext?: ClientEvaluationContext;
@@ -168,7 +168,7 @@ T extends string = string
     /**
      * Initialise the sdk against a particular environment
      */
-    init: (config: IInitConfig<F, T>) => Promise<void>;
+    init: (config: IInitConfig<FKey<F>, T>) => Promise<void>;
     /**
      * Set evaluation context. Refresh the flags.
      */

--- a/types.d.ts
+++ b/types.d.ts
@@ -49,7 +49,7 @@ export interface IRetrieveInfo {
 
 export interface IState<F extends string = string> {
     api: string;
-    flags?: IFlags<F>;
+    flags?: IFlags<FKey<F>>;
     evaluationContext?: EvaluationContext;
     evaluationEvent?: Record<string, Record<string, number>> | null;
     ts?: number;
@@ -89,7 +89,7 @@ export declare type LoadingState = {
     source: FlagSource //Indicates freshness of flags
 }
 
-export type OnChange<F extends string = string> = (previousFlags: IFlags<F> | null, params: IRetrieveInfo, loadingState:LoadingState) => void
+export type OnChange<F extends string = string> = (previousFlags: IFlags<FKey<F>> | null, params: IRetrieveInfo, loadingState:LoadingState) => void
 
 export type ApplicationMetadata = {
     name: string;
@@ -103,7 +103,7 @@ export interface IInitConfig<F extends string = string, T extends string = strin
     cacheFlags?: boolean;
     cacheOptions?: ICacheOptions;
     datadogRum?: IDatadogRum;
-    defaultFlags?: IFlags<F>;
+    defaultFlags?: IFlags<FKey<F>>;
     fetch?: any;
     realtime?: boolean;
     eventSourceUrl?: string;
@@ -189,7 +189,7 @@ T extends string = string
     /**
      * Returns the current flags
      */
-    getAllFlags: () => IFlags<F>;
+    getAllFlags: () => IFlags<FKey<F>>;
     /**
      * Identify user, triggers a call to get flags if `flagsmith.init` has been called
      * */


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Type fix for #314 

It was done for react but not JS client

- Reworked client types to use `FKey<F>` that includes keyof F
- Added tests

## How did you test this code?
- Locally
- Tests

## Steps to test
```
interface MyFeatureInterface {
  featureOne: string;
  featureTwo: boolean;
}

```
- Link js-client with local app
- create new flagsmith client as `const typedFlagsmith = flagsmith as IFlagsmith<MyFeatureInterface>;` 
- Try out different types combinations
