### PR TITLE
Align `FlagsmithProvider` children prop type with `React.ReactNode` in declaration file

### DIFF
--- a/react.d.ts
+++ b/react.d.ts
@@ -6,7 +6,7 @@ export declare type FlagsmithContextType<F extends string = string, T extends st
     flagsmith: IFlagsmith<F, T>;
     options?: Parameters<IFlagsmith<F, T>['init']>[0];
     serverState?: IState;
-    children: React.ReactElement[] | React.ReactElement;
+    children: React.ReactNode;
 };
 type UseFlagsReturn<
     F extends string | Record<string, any>,

--- a/test/react-types.test.tsx
+++ b/test/react-types.test.tsx
@@ -122,4 +122,15 @@ describe.only('FlagsmithProvider', () => {
             </FlagsmithProvider>
         );
     });
+    it('should compile if children prop is React.ReactNode', () => {
+        const { flagsmith, initConfig } = getFlagsmith();
+        const children: React.ReactNode = "I am a ReactNode child";
+        const { container } = render(
+            <FlagsmithProvider flagsmith={flagsmith} options={initConfig}>
+                {children}
+            </FlagsmithProvider>
+        );
+
+        expect(container.textContent).toBe(children);
+    });
 });


### PR DESCRIPTION
This PR resolves a remaining type inconsistency related to issue #268 and PR #270 regarding the `FlagsmithProvider` component, where its `children` prop in the TypeScript declaration file (`react.d.ts`) mismatched the `React.ReactNode` type used in the implementation (`react.tsx`).

Also added a test to `test/react-types.test.tsx` to assert that `FlagsmithProvider` renders a `React.ReactNode` correctly and the TS declaration file types match the implementation file (otherwise the test itself fails to compile). 