### PR TITLE
fix: renamed-sentry-client-interface

### DIFF
--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -9,7 +9,7 @@ import {
     IFlagsmithResponse,
     IFlagsmithTrait,
     IInitConfig,
-    ISentry,
+    ISentryClient,
     IState,
     ITraits,
     LoadingState,
@@ -287,7 +287,7 @@ const Flagsmith = class {
     ticks: number|null= null
     timer: number|null= null
     dtrum= null
-    sentryClient: ISentry | null = null
+    sentryClient: ISentryClient | null = null
     withTraits?: ITraits|null= null
     cacheOptions = {ttl:0, skipAPI: false, loadStale: false, storageKey: undefined as string|undefined}
     async init(config: IInitConfig) {

--- a/types.d.ts
+++ b/types.d.ts
@@ -77,7 +77,7 @@ export declare type IDatadogRum = {
 }
 
 
-export type ISentry = {
+export type ISentryClient = {
     getIntegrationByName(name:"FeatureFlags"): {
         addFeatureFlag(flag: string, enabled: boolean): void;
     } | undefined;


### PR DESCRIPTION
Closes #334 

Forgotten interface renaming