### PR TITLE
feat: add useExperiment hook with backend-aligned two-trait convention

### DIFF
--- a/react.d.ts
+++ b/react.d.ts
@@ -30,3 +30,9 @@ export declare function useFlags<
 export declare const useFlagsmith: <F extends string | Record<string, any>,
     T extends string = string>() => IFlagsmith<F, T>;
 export declare const useFlagsmithLoading: () => LoadingState | undefined;
+export declare function useExperiment(flagKey: string): {
+    enabled: boolean;
+    value: IFlagsmithValue;
+    success: () => Promise<void>;
+    failure: () => Promise<void>;
+};


### PR DESCRIPTION
Auto-enrolls users by setting `exp_{key}_variant` trait on render, and reports outcomes via `exp_{key}_converted` trait to match the backend experiment analytics endpoint.