### PR TITLE
fix: removed-react-native-publishing

### DIFF
--- a/.github/workflows/publish-internal.yml
+++ b/.github/workflows/publish-internal.yml
@@ -29,7 +29,6 @@ jobs:
           INTERNAL="${VERSION}-internal.${{ github.run_number }}"
           echo "Publishing version: $INTERNAL"
           cd lib/flagsmith && npm version $INTERNAL --no-git-tag-version
-          cd ../../lib/react-native-flagsmith && npm version $INTERNAL --no-git-tag-version
 
       - name: Build and test
         run: npm run build && npm test
@@ -37,4 +36,3 @@ jobs:
       - name: Publish
         run: |
           cd lib/flagsmith && npm publish --tag internal --access public
-          cd ../../lib/react-native-flagsmith && npm publish --tag internal --access public


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
As we rarely use react-native, there is no need to publish the internal version. As OIDC is not configured, it raises an error and mark the workflow as failed
