### PR TITLE
feat: add trackEvent for custom pipeline events

### DIFF
--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -1012,13 +1012,6 @@ const Flagsmith = class {
         this.pipelineRecordedKeys.clear();
     }
 
-    private trimPipelineBuffer() {
-        if (this.pipelineEvents.length > this.evaluationAnalyticsMaxBuffer) {
-            const excess = this.pipelineEvents.length - this.evaluationAnalyticsMaxBuffer;
-            this.pipelineEvents = this.pipelineEvents.slice(excess);
-        }
-    }
-
     private currentTraitsSnapshot() {
         return this.evaluationContext.identity?.traits
             ? { ...this.evaluationContext.identity.traits }
@@ -1090,9 +1083,8 @@ const Flagsmith = class {
             extraMetadata: metadata,
         });
         this.pipelineEvents.push(event);
-        this.trimPipelineBuffer();
 
-        if (this.pipelineFlushInterval === 0) {
+        if (this.pipelineFlushInterval === 0 || this.pipelineEvents.length >= this.evaluationAnalyticsMaxBuffer) {
             this.flushPipelineAnalytics();
         }
     }

--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -36,6 +36,11 @@ export enum FlagSource {
     "SERVER" = "SERVER",
 }
 
+export enum PipelineEventType {
+    FLAG_EVALUATION = 'flag_evaluation',
+    CUSTOM_EVENT = 'custom_event',
+}
+
 export type LikeFetch = (input: Partial<RequestInfo>, init?: Partial<RequestInit>) => Promise<Partial<Response>>
 let _fetch: LikeFetch;
 
@@ -1060,7 +1065,7 @@ const Flagsmith = class {
         this.pipelineRecordedKeys.set(flagKey, fingerprint);
         const event: IPipelineEvent = {
             event_id: flagKey,
-            event_type: 'flag_evaluation',
+            event_type: PipelineEventType.FLAG_EVALUATION,
             evaluated_at: Date.now(),
             identity_identifier: this.evaluationContext.identity?.identifier ?? null,
             enabled: flag ? flag.enabled : null,
@@ -1084,7 +1089,7 @@ const Flagsmith = class {
     private buildCustomEvent(eventName: string, identityIdentifier: string | null, metadata?: Record<string, unknown>, timestamp?: number): IPipelineEvent {
         return {
             event_id: eventName,
-            event_type: 'custom_event',
+            event_type: PipelineEventType.CUSTOM_EVENT,
             evaluated_at: timestamp ?? Date.now(),
             identity_identifier: identityIdentifier,
             enabled: null,

--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -339,6 +339,7 @@ const Flagsmith = class {
     pipelineAnalyticsInterval: ReturnType<typeof setInterval> | null = null
     isPipelineFlushing = false
     pipelineRecordedKeys: Map<string, string> = new Map()
+    pendingCustomEvents: Array<{ eventName: string; metadata?: Record<string, any>; timestamp: number }> = []
     async init(config: IInitConfig) {
         const evaluationContext = toEvaluationContext(config.evaluationContext || this.evaluationContext);
         try {
@@ -653,6 +654,18 @@ const Flagsmith = class {
                 )
             );
         }
+        // Drain pending custom events now that identity is set
+        if (this.pendingCustomEvents.length > 0 && this.evaluationAnalyticsUrl) {
+            for (const pending of this.pendingCustomEvents) {
+                const event = this.buildCustomEvent(pending.eventName, userId ?? null, pending.metadata, pending.timestamp);
+                this.pipelineEvents.push(event);
+            }
+            this.pendingCustomEvents = [];
+            this.trimPipelineBuffer();
+            if (this.pipelineFlushInterval === 0) {
+                this.flushPipelineAnalytics();
+            }
+        }
         if (this.initialised) {
             return this.getFlags();
         }
@@ -685,6 +698,7 @@ const Flagsmith = class {
     logout() {
         this.identity = null
         this.evaluationContext.identity = null;
+        this.pendingCustomEvents = [];
         if (this.initialised) {
             return this.getFlags();
         }
@@ -1004,7 +1018,34 @@ const Flagsmith = class {
         }
         this.evaluationAnalyticsUrl = null;
         this.pipelineEvents = [];
+        this.pendingCustomEvents = [];
         this.pipelineRecordedKeys.clear();
+    }
+
+    private trimPipelineBuffer() {
+        if (this.pipelineEvents.length > this.evaluationAnalyticsMaxBuffer) {
+            const excess = this.pipelineEvents.length - this.evaluationAnalyticsMaxBuffer;
+            this.pipelineEvents = this.pipelineEvents.slice(excess);
+        }
+    }
+
+    private currentTraitsSnapshot() {
+        return this.evaluationContext.identity?.traits
+            ? { ...this.evaluationContext.identity.traits }
+            : null;
+    }
+
+    private getPageUrl(): string | null {
+        return typeof window !== 'undefined' && window.location ? window.location.href : null;
+    }
+
+    private sdkMetadata(extra?: Record<string, any>): Record<string, any> {
+        const pageUrl = this.getPageUrl();
+        return {
+            ...(extra || {}),
+            ...(pageUrl ? { page_url: pageUrl } : {}),
+            ...(SDK_VERSION ? { sdk_version: SDK_VERSION } : {}),
+        };
     }
 
     // Pipeline event schema — must match the pipeline server's Event struct.
@@ -1036,6 +1077,38 @@ const Flagsmith = class {
         this.pipelineEvents.push(event);
 
         if (this.pipelineFlushInterval === 0 || this.pipelineEvents.length >= this.evaluationAnalyticsMaxBuffer) {
+            this.flushPipelineAnalytics();
+        }
+    }
+
+    private buildCustomEvent(eventName: string, identityIdentifier: string | null, metadata?: Record<string, any>, timestamp?: number): IPipelineEvent {
+        return {
+            event_id: eventName,
+            event_type: 'custom_event',
+            evaluated_at: timestamp ?? Date.now(),
+            identity_identifier: identityIdentifier,
+            enabled: null,
+            value: null,
+            traits: this.currentTraitsSnapshot(),
+            metadata: this.sdkMetadata(metadata),
+        };
+    }
+
+    trackEvent = (eventName: string, metadata?: Record<string, any>) => {
+        if (!this.evaluationAnalyticsUrl || !eventName) {
+            return;
+        }
+        if (!this.evaluationContext.identity?.identifier) {
+            if (this.pendingCustomEvents.length < this.evaluationAnalyticsMaxBuffer) {
+                this.pendingCustomEvents.push({ eventName, metadata, timestamp: Date.now() });
+            }
+            return;
+        }
+        const event = this.buildCustomEvent(eventName, this.evaluationContext.identity.identifier, metadata);
+        this.pipelineEvents.push(event);
+        this.trimPipelineBuffer();
+
+        if (this.pipelineFlushInterval === 0) {
             this.flushPipelineAnalytics();
         }
     }

--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -344,7 +344,6 @@ const Flagsmith = class {
     private pipelineAnalyticsInterval: ReturnType<typeof setInterval> | null = null
     private isPipelineFlushing = false
     private pipelineRecordedKeys: Map<string, string> = new Map()
-    private pendingCustomEvents: Array<{ eventName: string; metadata?: Record<string, unknown>; timestamp: number }> = []
     async init(config: IInitConfig) {
         const evaluationContext = toEvaluationContext(config.evaluationContext || this.evaluationContext);
         try {
@@ -659,18 +658,6 @@ const Flagsmith = class {
                 )
             );
         }
-        // Drain pending custom events now that identity is set
-        if (this.pendingCustomEvents.length > 0 && this.evaluationAnalyticsUrl) {
-            for (const pending of this.pendingCustomEvents) {
-                const event = this.buildCustomEvent(pending.eventName, userId ?? null, pending.metadata, pending.timestamp);
-                this.pipelineEvents.push(event);
-            }
-            this.pendingCustomEvents = [];
-            this.trimPipelineBuffer();
-            if (this.pipelineFlushInterval === 0) {
-                this.flushPipelineAnalytics();
-            }
-        }
         if (this.initialised) {
             return this.getFlags();
         }
@@ -703,7 +690,6 @@ const Flagsmith = class {
     logout() {
         this.identity = null
         this.evaluationContext.identity = null;
-        this.pendingCustomEvents = [];
         if (this.initialised) {
             return this.getFlags();
         }
@@ -1023,7 +1009,6 @@ const Flagsmith = class {
         }
         this.evaluationAnalyticsUrl = null;
         this.pipelineEvents = [];
-        this.pendingCustomEvents = [];
         this.pipelineRecordedKeys.clear();
     }
 
@@ -1103,13 +1088,7 @@ const Flagsmith = class {
         if (!this.evaluationAnalyticsUrl || !eventName) {
             return;
         }
-        if (!this.evaluationContext.identity?.identifier) {
-            if (this.pendingCustomEvents.length < this.evaluationAnalyticsMaxBuffer) {
-                this.pendingCustomEvents.push({ eventName, metadata, timestamp: Date.now() });
-            }
-            return;
-        }
-        const event = this.buildCustomEvent(eventName, this.evaluationContext.identity.identifier, metadata);
+        const event = this.buildCustomEvent(eventName, this.evaluationContext.identity?.identifier ?? null, metadata);
         this.pipelineEvents.push(event);
         this.trimPipelineBuffer();
 

--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -338,13 +338,13 @@ const Flagsmith = class {
     sentryClient: ISentryClient | null = null
     withTraits?: ITraits|null= null
     cacheOptions = {ttl:0, skipAPI: false, loadStale: false, storageKey: undefined as string|undefined}
-    evaluationAnalyticsUrl: string | null = null
-    evaluationAnalyticsMaxBuffer: number = 1000
-    pipelineEvents: IPipelineEvent[] = []
-    pipelineAnalyticsInterval: ReturnType<typeof setInterval> | null = null
-    isPipelineFlushing = false
-    pipelineRecordedKeys: Map<string, string> = new Map()
-    pendingCustomEvents: Array<{ eventName: string; metadata?: Record<string, unknown>; timestamp: number }> = []
+    private evaluationAnalyticsUrl: string | null = null
+    private evaluationAnalyticsMaxBuffer: number = 1000
+    private pipelineEvents: IPipelineEvent[] = []
+    private pipelineAnalyticsInterval: ReturnType<typeof setInterval> | null = null
+    private isPipelineFlushing = false
+    private pipelineRecordedKeys: Map<string, string> = new Map()
+    private pendingCustomEvents: Array<{ eventName: string; metadata?: Record<string, unknown>; timestamp: number }> = []
     async init(config: IInitConfig) {
         const evaluationContext = toEvaluationContext(config.evaluationContext || this.evaluationContext);
         try {

--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -339,7 +339,7 @@ const Flagsmith = class {
     pipelineAnalyticsInterval: ReturnType<typeof setInterval> | null = null
     isPipelineFlushing = false
     pipelineRecordedKeys: Map<string, string> = new Map()
-    pendingCustomEvents: Array<{ eventName: string; metadata?: Record<string, any>; timestamp: number }> = []
+    pendingCustomEvents: Array<{ eventName: string; metadata?: Record<string, unknown>; timestamp: number }> = []
     async init(config: IInitConfig) {
         const evaluationContext = toEvaluationContext(config.evaluationContext || this.evaluationContext);
         try {
@@ -1039,7 +1039,7 @@ const Flagsmith = class {
         return typeof window !== 'undefined' && window.location ? window.location.href : null;
     }
 
-    private sdkMetadata(extra?: Record<string, any>): Record<string, any> {
+    private sdkMetadata(extra?: Record<string, unknown>): Record<string, unknown> {
         const pageUrl = this.getPageUrl();
         return {
             ...(extra || {}),
@@ -1081,7 +1081,7 @@ const Flagsmith = class {
         }
     }
 
-    private buildCustomEvent(eventName: string, identityIdentifier: string | null, metadata?: Record<string, any>, timestamp?: number): IPipelineEvent {
+    private buildCustomEvent(eventName: string, identityIdentifier: string | null, metadata?: Record<string, unknown>, timestamp?: number): IPipelineEvent {
         return {
             event_id: eventName,
             event_type: 'custom_event',
@@ -1094,7 +1094,7 @@ const Flagsmith = class {
         };
     }
 
-    trackEvent = (eventName: string, metadata?: Record<string, any>) => {
+    trackEvent = (eventName: string, metadata?: Record<string, unknown>) => {
         if (!this.evaluationAnalyticsUrl || !eventName) {
             return;
         }

--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -1029,7 +1029,7 @@ const Flagsmith = class {
         return typeof window !== 'undefined' && window.location ? window.location.href : null;
     }
 
-    private sdkMetadata(extra?: Record<string, unknown>): Record<string, unknown> {
+    private getEventMetadata(extra?: Record<string, unknown>): Record<string, unknown> {
         const pageUrl = this.getPageUrl();
         return {
             ...(extra || {}),
@@ -1040,6 +1040,28 @@ const Flagsmith = class {
 
     // Pipeline event schema — must match the pipeline server's Event struct.
     // To update: 1) IPipelineEvent in types.d.ts  2) event object below  3) tests in test/analytics-pipeline.test.ts
+    private buildAnalyticEvent(
+        eventType: PipelineEventType,
+        eventId: string,
+        options?: {
+            enabled?: boolean | null;
+            value?: any;
+            extraMetadata?: Record<string, unknown>;
+            timestamp?: number;
+        },
+    ): IPipelineEvent {
+        return {
+            event_id: eventId,
+            event_type: eventType,
+            evaluated_at: options?.timestamp ?? Date.now(),
+            identity_identifier: this.evaluationContext.identity?.identifier ?? null,
+            enabled: options?.enabled ?? null,
+            value: options?.value ?? null,
+            traits: this.currentTraitsSnapshot(),
+            metadata: this.getEventMetadata(options?.extraMetadata),
+        };
+    }
+
     private recordPipelineEvent(key: string) {
         const flagKey = key.toLowerCase().replace(/ /g, '_');
         const flag = this.flags && this.flags[flagKey];
@@ -1048,22 +1070,11 @@ const Flagsmith = class {
             return;
         }
         this.pipelineRecordedKeys.set(flagKey, fingerprint);
-        const event: IPipelineEvent = {
-            event_id: flagKey,
-            event_type: PipelineEventType.FLAG_EVALUATION,
-            evaluated_at: Date.now(),
-            identity_identifier: this.evaluationContext.identity?.identifier ?? null,
+        const event = this.buildAnalyticEvent(PipelineEventType.FLAG_EVALUATION, flagKey, {
             enabled: flag ? flag.enabled : null,
             value: flag ? flag.value : null,
-            traits: this.evaluationContext.identity?.traits
-                ? { ...this.evaluationContext.identity.traits }
-                : null,
-            metadata: {
-                ...(flag ? { id: flag.id } : {}),
-                ...(typeof window !== 'undefined' && window.location ? { page_url: window.location.href } : {}),
-                ...(SDK_VERSION ? { sdk_version: SDK_VERSION } : {}),
-            },
-        };
+            extraMetadata: flag ? { id: flag.id } : undefined,
+        });
         this.pipelineEvents.push(event);
 
         if (this.pipelineFlushInterval === 0 || this.pipelineEvents.length >= this.evaluationAnalyticsMaxBuffer) {
@@ -1071,24 +1082,13 @@ const Flagsmith = class {
         }
     }
 
-    private buildCustomEvent(eventName: string, identityIdentifier: string | null, metadata?: Record<string, unknown>, timestamp?: number): IPipelineEvent {
-        return {
-            event_id: eventName,
-            event_type: PipelineEventType.CUSTOM_EVENT,
-            evaluated_at: timestamp ?? Date.now(),
-            identity_identifier: identityIdentifier,
-            enabled: null,
-            value: null,
-            traits: this.currentTraitsSnapshot(),
-            metadata: this.sdkMetadata(metadata),
-        };
-    }
-
     trackEvent = (eventName: string, metadata?: Record<string, unknown>) => {
         if (!this.evaluationAnalyticsUrl || !eventName) {
             return;
         }
-        const event = this.buildCustomEvent(eventName, this.evaluationContext.identity?.identifier ?? null, metadata);
+        const event = this.buildAnalyticEvent(PipelineEventType.CUSTOM_EVENT, eventName, {
+            extraMetadata: metadata,
+        });
         this.pipelineEvents.push(event);
         this.trimPipelineBuffer();
 

--- a/index.ts
+++ b/index.ts
@@ -19,4 +19,4 @@ export default flagsmith;
 export const createFlagsmithInstance = ():IFlagsmith=>{
     return core({ AsyncStorage, fetch:_fetch, eventSource:_EventSource})
 }
-export { FlagSource } from './flagsmith-core';
+export { FlagSource, PipelineEventType } from './flagsmith-core';

--- a/test/analytics-pipeline.test.ts
+++ b/test/analytics-pipeline.test.ts
@@ -218,3 +218,189 @@ describe('Pipeline Analytics', () => {
         expect(flagsmith.pipelineEvents[0].event_id).toBe('hero');
     });
 });
+
+const defaultPipelineConfig = {
+    evaluationAnalyticsConfig: {
+        analyticsServerUrl: pipelineUrl,
+        flushInterval: 60000,
+    },
+};
+
+function getCustomEvents(flagsmith: any) {
+    return flagsmith.pipelineEvents.filter((e: any) => e.event_type === 'custom_event');
+}
+
+describe('trackEvent (custom events)', () => {
+    test('sends custom_event with correct shape', async () => {
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith({
+            ...defaultPipelineConfig,
+            identity: testIdentity,
+        });
+        await flagsmith.init(initConfig);
+
+        flagsmith.trackEvent('checkout', { item: 'shoes', price: 99 });
+        // @ts-ignore
+        await flagsmith.flushPipelineAnalytics();
+
+        const calls = getPipelineCalls(mockFetch);
+        expect(calls).toHaveLength(1);
+
+        const event = JSON.parse(calls[0][1].body).events[0];
+        expect(event).toEqual(expect.objectContaining({
+            event_id: 'checkout',
+            event_type: 'custom_event',
+            enabled: null,
+            value: null,
+            identity_identifier: testIdentity,
+        }));
+        expect(event.evaluated_at).toEqual(expect.any(Number));
+        expect(event.metadata).toEqual(expect.objectContaining({ item: 'shoes', price: 99 }));
+        expect(event.metadata.sdk_version).toBeDefined();
+    });
+
+    test('no-ops when evaluationAnalyticsConfig is not set', async () => {
+        const { flagsmith, initConfig } = getFlagsmith();
+        await flagsmith.init(initConfig);
+
+        flagsmith.trackEvent('checkout');
+
+        // @ts-ignore
+        expect(flagsmith.pipelineEvents).toHaveLength(0);
+        // @ts-ignore
+        expect(flagsmith.pendingCustomEvents).toHaveLength(0);
+    });
+
+    test('no-ops when eventName is empty', async () => {
+        const { flagsmith, initConfig } = getFlagsmith({
+            ...defaultPipelineConfig,
+            identity: testIdentity,
+        });
+        await flagsmith.init(initConfig);
+
+        flagsmith.trackEvent('');
+
+        // @ts-ignore
+        expect(flagsmith.pipelineEvents).toHaveLength(0);
+        // @ts-ignore
+        expect(flagsmith.pendingCustomEvents).toHaveLength(0);
+    });
+
+    test('queues events before identify and drains on identify', async () => {
+        const { flagsmith, initConfig } = getFlagsmith(defaultPipelineConfig);
+        await flagsmith.init(initConfig);
+
+        flagsmith.trackEvent('page_view', { page: '/home' });
+        flagsmith.trackEvent('signup');
+
+        // @ts-ignore
+        expect(flagsmith.pendingCustomEvents).toHaveLength(2);
+        expect(getCustomEvents(flagsmith)).toHaveLength(0);
+
+        await flagsmith.identify(testIdentity);
+
+        // @ts-ignore
+        expect(flagsmith.pendingCustomEvents).toHaveLength(0);
+        const custom = getCustomEvents(flagsmith);
+        expect(custom).toHaveLength(2);
+        expect(custom[0].event_id).toBe('page_view');
+        expect(custom[0].identity_identifier).toBe(testIdentity);
+        expect(custom[1].event_id).toBe('signup');
+        expect(custom[1].identity_identifier).toBe(testIdentity);
+    });
+
+    test('flushes immediately on identify when flushInterval is 0', async () => {
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith({
+            evaluationAnalyticsConfig: {
+                analyticsServerUrl: pipelineUrl,
+                flushInterval: 0,
+            },
+        });
+        await flagsmith.init(initConfig);
+
+        flagsmith.trackEvent('pre_identify_action');
+        expect(getPipelineCalls(mockFetch)).toHaveLength(0);
+
+        await flagsmith.identify(testIdentity);
+
+        const calls = getPipelineCalls(mockFetch);
+        expect(calls.length).toBeGreaterThanOrEqual(1);
+
+        const allEvents = calls.flatMap(
+            ([, opts]: [string, any]) => JSON.parse(opts.body).events
+        );
+        const custom = allEvents.filter((e: any) => e.event_type === 'custom_event');
+        expect(custom).toHaveLength(1);
+        expect(custom[0].event_id).toBe('pre_identify_action');
+        expect(custom[0].identity_identifier).toBe(testIdentity);
+    });
+
+    test('does not deduplicate - each call produces a distinct event', async () => {
+        const { flagsmith, initConfig } = getFlagsmith({
+            ...defaultPipelineConfig,
+            identity: testIdentity,
+        });
+        await flagsmith.init(initConfig);
+
+        flagsmith.trackEvent('click');
+        flagsmith.trackEvent('click');
+        flagsmith.trackEvent('click');
+
+        expect(getCustomEvents(flagsmith)).toHaveLength(3);
+    });
+
+    test('preserves original timestamps for queued events', async () => {
+        const { flagsmith, initConfig } = getFlagsmith(defaultPipelineConfig);
+        await flagsmith.init(initConfig);
+
+        const trackTime = 1700000000000;
+        const identifyTime = 1700000005000;
+        const dateSpy = jest.spyOn(Date, 'now');
+
+        dateSpy.mockReturnValue(trackTime);
+        flagsmith.trackEvent('early_event');
+
+        dateSpy.mockReturnValue(identifyTime);
+        await flagsmith.identify(testIdentity);
+        dateSpy.mockRestore();
+
+        const custom = getCustomEvents(flagsmith);
+        expect(custom).toHaveLength(1);
+        expect(custom[0].evaluated_at).toBe(trackTime);
+    });
+
+    test('clears pending events on logout', async () => {
+        const { flagsmith, initConfig } = getFlagsmith(defaultPipelineConfig);
+        await flagsmith.init(initConfig);
+
+        flagsmith.trackEvent('pre_login_action');
+        // @ts-ignore
+        expect(flagsmith.pendingCustomEvents).toHaveLength(1);
+
+        await flagsmith.logout();
+
+        // @ts-ignore
+        expect(flagsmith.pendingCustomEvents).toHaveLength(0);
+    });
+
+    test('respects maxBuffer for pending events', async () => {
+        const { flagsmith, initConfig } = getFlagsmith({
+            evaluationAnalyticsConfig: {
+                analyticsServerUrl: pipelineUrl,
+                maxBuffer: 2,
+                flushInterval: 60000,
+            },
+        });
+        await flagsmith.init(initConfig);
+
+        flagsmith.trackEvent('event_1');
+        flagsmith.trackEvent('event_2');
+        flagsmith.trackEvent('event_3');
+
+        // @ts-ignore
+        expect(flagsmith.pendingCustomEvents).toHaveLength(2);
+        // @ts-ignore
+        expect(flagsmith.pendingCustomEvents[0].eventName).toBe('event_1');
+        // @ts-ignore
+        expect(flagsmith.pendingCustomEvents[1].eventName).toBe('event_2');
+    });
+});

--- a/test/analytics-pipeline.test.ts
+++ b/test/analytics-pipeline.test.ts
@@ -267,8 +267,6 @@ describe('trackEvent (custom events)', () => {
 
         // @ts-ignore
         expect(flagsmith.pipelineEvents).toHaveLength(0);
-        // @ts-ignore
-        expect(flagsmith.pendingCustomEvents).toHaveLength(0);
     });
 
     test('no-ops when eventName is empty', async () => {
@@ -282,46 +280,54 @@ describe('trackEvent (custom events)', () => {
 
         // @ts-ignore
         expect(flagsmith.pipelineEvents).toHaveLength(0);
-        // @ts-ignore
-        expect(flagsmith.pendingCustomEvents).toHaveLength(0);
     });
 
-    test('queues events before identify and drains on identify', async () => {
-        const { flagsmith, initConfig } = getFlagsmith(defaultPipelineConfig);
+    test('tracks events with null identity when not identified', async () => {
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith(defaultPipelineConfig);
         await flagsmith.init(initConfig);
 
         flagsmith.trackEvent('page_view', { page: '/home' });
         flagsmith.trackEvent('signup');
 
-        // @ts-ignore
-        expect(flagsmith.pendingCustomEvents).toHaveLength(2);
-        expect(getCustomEvents(flagsmith)).toHaveLength(0);
-
-        await flagsmith.identify(testIdentity);
-
-        // @ts-ignore
-        expect(flagsmith.pendingCustomEvents).toHaveLength(0);
         const custom = getCustomEvents(flagsmith);
         expect(custom).toHaveLength(2);
         expect(custom[0].event_id).toBe('page_view');
-        expect(custom[0].identity_identifier).toBe(testIdentity);
+        expect(custom[0].identity_identifier).toBeNull();
+        expect(custom[0].metadata).toEqual(expect.objectContaining({ page: '/home' }));
         expect(custom[1].event_id).toBe('signup');
+        expect(custom[1].identity_identifier).toBeNull();
+
+        // @ts-ignore
+        await flagsmith.flushPipelineAnalytics();
+        const calls = getPipelineCalls(mockFetch);
+        expect(calls).toHaveLength(1);
+    });
+
+    test('tracks events with identity after identify', async () => {
+        const { flagsmith, initConfig } = getFlagsmith(defaultPipelineConfig);
+        await flagsmith.init(initConfig);
+
+        flagsmith.trackEvent('anonymous_action');
+        await flagsmith.identify(testIdentity);
+        flagsmith.trackEvent('identified_action');
+
+        const custom = getCustomEvents(flagsmith);
+        expect(custom).toHaveLength(2);
+        expect(custom[0].identity_identifier).toBeNull();
         expect(custom[1].identity_identifier).toBe(testIdentity);
     });
 
-    test('flushes immediately on identify when flushInterval is 0', async () => {
+    test('flushes immediately when flushInterval is 0', async () => {
         const { flagsmith, initConfig, mockFetch } = getFlagsmith({
             evaluationAnalyticsConfig: {
                 analyticsServerUrl: pipelineUrl,
                 flushInterval: 0,
             },
+            identity: testIdentity,
         });
         await flagsmith.init(initConfig);
 
-        flagsmith.trackEvent('pre_identify_action');
-        expect(getPipelineCalls(mockFetch)).toHaveLength(0);
-
-        await flagsmith.identify(testIdentity);
+        flagsmith.trackEvent('instant_event');
 
         const calls = getPipelineCalls(mockFetch);
         expect(calls.length).toBeGreaterThanOrEqual(1);
@@ -331,8 +337,7 @@ describe('trackEvent (custom events)', () => {
         );
         const custom = allEvents.filter((e: any) => e.event_type === PipelineEventType.CUSTOM_EVENT);
         expect(custom).toHaveLength(1);
-        expect(custom[0].event_id).toBe('pre_identify_action');
-        expect(custom[0].identity_identifier).toBe(testIdentity);
+        expect(custom[0].event_id).toBe('instant_event');
     });
 
     test('does not deduplicate - each call produces a distinct event', async () => {
@@ -349,81 +354,18 @@ describe('trackEvent (custom events)', () => {
         expect(getCustomEvents(flagsmith)).toHaveLength(3);
     });
 
-    test('preserves original timestamps for queued events', async () => {
+    test('tracks with null identity after logout', async () => {
         const { flagsmith, initConfig } = getFlagsmith(defaultPipelineConfig);
         await flagsmith.init(initConfig);
 
-        const trackTime = 1700000000000;
-        const identifyTime = 1700000005000;
-        const dateSpy = jest.spyOn(Date, 'now');
-
-        dateSpy.mockReturnValue(trackTime);
-        flagsmith.trackEvent('early_event');
-
-        dateSpy.mockReturnValue(identifyTime);
-        await flagsmith.identify(testIdentity);
-        dateSpy.mockRestore();
-
-        const custom = getCustomEvents(flagsmith);
-        expect(custom).toHaveLength(1);
-        expect(custom[0].evaluated_at).toBe(trackTime);
-    });
-
-    test('clears pending events on logout', async () => {
-        const { flagsmith, initConfig } = getFlagsmith(defaultPipelineConfig);
-        await flagsmith.init(initConfig);
-
-        flagsmith.trackEvent('pre_login_action');
-        // @ts-ignore
-        expect(flagsmith.pendingCustomEvents).toHaveLength(1);
-
-        await flagsmith.logout();
-
-        // @ts-ignore
-        expect(flagsmith.pendingCustomEvents).toHaveLength(0);
-    });
-
-    test('respects maxBuffer for pending events', async () => {
-        const { flagsmith, initConfig } = getFlagsmith({
-            evaluationAnalyticsConfig: {
-                analyticsServerUrl: pipelineUrl,
-                maxBuffer: 2,
-                flushInterval: 60000,
-            },
-        });
-        await flagsmith.init(initConfig);
-
-        flagsmith.trackEvent('event_1');
-        flagsmith.trackEvent('event_2');
-        flagsmith.trackEvent('event_3');
-
-        // @ts-ignore
-        expect(flagsmith.pendingCustomEvents).toHaveLength(2);
-        // @ts-ignore
-        expect(flagsmith.pendingCustomEvents[0].eventName).toBe('event_1');
-        // @ts-ignore
-        expect(flagsmith.pendingCustomEvents[1].eventName).toBe('event_2');
-    });
-
-    test('buffers again after identify then logout', async () => {
-        const { flagsmith, initConfig } = getFlagsmith(defaultPipelineConfig);
-        await flagsmith.init(initConfig);
-
-        // Identify → track goes direct to pipeline
         await flagsmith.identify(testIdentity);
         flagsmith.trackEvent('while_identified');
-        expect(getCustomEvents(flagsmith)).toHaveLength(1);
+        expect(getCustomEvents(flagsmith)[0].identity_identifier).toBe(testIdentity);
 
-        // Logout → clears pending, identity gone
         await flagsmith.logout();
-        // @ts-ignore
-        expect(flagsmith.pendingCustomEvents).toHaveLength(0);
 
-        // Track after logout → should buffer again (no identity)
         flagsmith.trackEvent('after_logout');
-        // @ts-ignore
-        expect(flagsmith.pendingCustomEvents).toHaveLength(1);
-        // @ts-ignore
-        expect(flagsmith.pendingCustomEvents[0].eventName).toBe('after_logout');
+        const custom = getCustomEvents(flagsmith);
+        expect(custom[custom.length - 1].identity_identifier).toBeNull();
     });
 });

--- a/test/analytics-pipeline.test.ts
+++ b/test/analytics-pipeline.test.ts
@@ -1,4 +1,5 @@
 import { getFlagsmith, environmentID, testIdentity } from './test-constants';
+import { PipelineEventType } from '../lib/flagsmith';
 
 const pipelineUrl = 'https://analytics.flagsmith.com/';
 
@@ -227,7 +228,7 @@ const defaultPipelineConfig = {
 };
 
 function getCustomEvents(flagsmith: any) {
-    return flagsmith.pipelineEvents.filter((e: any) => e.event_type === 'custom_event');
+    return flagsmith.pipelineEvents.filter((e: any) => e.event_type === PipelineEventType.CUSTOM_EVENT);
 }
 
 describe('trackEvent (custom events)', () => {
@@ -248,7 +249,7 @@ describe('trackEvent (custom events)', () => {
         const event = JSON.parse(calls[0][1].body).events[0];
         expect(event).toEqual(expect.objectContaining({
             event_id: 'checkout',
-            event_type: 'custom_event',
+            event_type: PipelineEventType.CUSTOM_EVENT,
             enabled: null,
             value: null,
             identity_identifier: testIdentity,
@@ -328,7 +329,7 @@ describe('trackEvent (custom events)', () => {
         const allEvents = calls.flatMap(
             ([, opts]: [string, any]) => JSON.parse(opts.body).events
         );
-        const custom = allEvents.filter((e: any) => e.event_type === 'custom_event');
+        const custom = allEvents.filter((e: any) => e.event_type === PipelineEventType.CUSTOM_EVENT);
         expect(custom).toHaveLength(1);
         expect(custom[0].event_id).toBe('pre_identify_action');
         expect(custom[0].identity_identifier).toBe(testIdentity);
@@ -402,5 +403,27 @@ describe('trackEvent (custom events)', () => {
         expect(flagsmith.pendingCustomEvents[0].eventName).toBe('event_1');
         // @ts-ignore
         expect(flagsmith.pendingCustomEvents[1].eventName).toBe('event_2');
+    });
+
+    test('buffers again after identify then logout', async () => {
+        const { flagsmith, initConfig } = getFlagsmith(defaultPipelineConfig);
+        await flagsmith.init(initConfig);
+
+        // Identify → track goes direct to pipeline
+        await flagsmith.identify(testIdentity);
+        flagsmith.trackEvent('while_identified');
+        expect(getCustomEvents(flagsmith)).toHaveLength(1);
+
+        // Logout → clears pending, identity gone
+        await flagsmith.logout();
+        // @ts-ignore
+        expect(flagsmith.pendingCustomEvents).toHaveLength(0);
+
+        // Track after logout → should buffer again (no identity)
+        flagsmith.trackEvent('after_logout');
+        // @ts-ignore
+        expect(flagsmith.pendingCustomEvents).toHaveLength(1);
+        // @ts-ignore
+        expect(flagsmith.pendingCustomEvents[0].eventName).toBe('after_logout');
     });
 });

--- a/types.d.ts
+++ b/types.d.ts
@@ -304,6 +304,7 @@ T extends string = string
      * Requires `evaluationAnalyticsConfig` to be set; no-op otherwise.
      * Events are sent with the current identity (or null if anonymous).
      * @experimental Internal use only — API may change without notice.
+     * @internal
      * @hidden
      */
     trackEvent: (eventName: string, metadata?: Record<string, unknown>) => void;

--- a/types.d.ts
+++ b/types.d.ts
@@ -302,7 +302,7 @@ T extends string = string
     /**
      * Track a custom event through the evaluation analytics pipeline.
      * Requires `evaluationAnalyticsConfig` to be set; no-op otherwise.
-     * Events tracked before `identify()` are buffered and sent once identity is set.
+     * Events are sent with the current identity (or null if anonymous).
      * @experimental Internal use only — API may change without notice.
      * @hidden
      */

--- a/types.d.ts
+++ b/types.d.ts
@@ -300,6 +300,14 @@ T extends string = string
      */
     setTraits: (traits: ITraits) => Promise<void>;
     /**
+     * Track a custom event through the evaluation analytics pipeline.
+     * Requires `evaluationAnalyticsConfig` to be set; no-op otherwise.
+     * Events tracked before `identify()` are buffered and sent once identity is set.
+     * @experimental Internal use only — API may change without notice.
+     * @hidden
+     */
+    trackEvent: (eventName: string, metadata?: Record<string, any>) => void;
+    /**
      * The stored identity of the user
     */
     identity?: IIdentity;

--- a/types.d.ts
+++ b/types.d.ts
@@ -306,7 +306,7 @@ T extends string = string
      * @experimental Internal use only — API may change without notice.
      * @hidden
      */
-    trackEvent: (eventName: string, metadata?: Record<string, any>) => void;
+    trackEvent: (eventName: string, metadata?: Record<string, unknown>) => void;
     /**
      * The stored identity of the user
     */

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,5 +1,5 @@
 import { EvaluationContext, IdentityEvaluationContext, TraitEvaluationContext } from "./evaluation-context";
-import { FlagSource } from "./flagsmith-core";
+import { FlagSource, PipelineEventType } from "./flagsmith-core";
 
 type IFlagsmithValue<T = string | number | boolean | null> = T
 
@@ -85,7 +85,7 @@ export type ISentryClient = {
 } | undefined;
 
 
-export { FlagSource };
+export { FlagSource, PipelineEventType };
 
 export declare type LoadingState = {
     error: Error | null, // Current error, resets on next attempt to fetch flags
@@ -147,7 +147,7 @@ export interface IInitConfig<F extends string | Record<string, any> = string, T 
 
 export interface IPipelineEvent {
     event_id: string; // flag_name or event_name
-    event_type: 'flag_evaluation' | 'custom_event';
+    event_type: PipelineEventType;
     evaluated_at: number;
     identity_identifier: string | null;
     enabled?: boolean | null;


### PR DESCRIPTION
## Summary
- Add `trackEvent(eventName, metadata?)` public method to send custom events through the evaluation analytics pipeline (`v1/analytics/batch`)
- Events are sent immediately with the current identity (or `null` if anonymous) — no buffering
- Pipeline-only: requires `evaluationAnalyticsConfig`; no-op otherwise
- Add `PipelineEventType` enum (`FLAG_EVALUATION`, `CUSTOM_EVENT`) to replace magic strings, exported from `index.ts` for consumer access
- Unify event building into shared `buildAnalyticEvent` method for both flag evaluations and custom events
- Rename `sdkMetadata` → `getEventMetadata`, reuse `currentTraitsSnapshot` across event types
- Make pipeline analytics properties private
- Uses `Record<string, unknown>` instead of `Record<string, any>` for metadata, enforcing type narrowing on consumers

## Test plan
- [x] Unit tests (8 new): correct event shape, no-op guards (no config, empty name), null identity when anonymous, identity after identify, flush on `flushInterval === 0`, no deduplication, null identity after logout
- [x] All 84 tests pass (no regressions)
- [x] Manual E2E validation with Angular playground app + local echo server