### PR TITLE
fix: update loadingState when hydrating via serverState

### DIFF
--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -623,6 +623,13 @@ const Flagsmith = class {
             this.evaluationEvent = state.evaluationEvent || this.evaluationEvent;
             this.identity = this.getContext()?.identity?.identifier
             this.log("setState called", this)
+            // Hydration from server state (e.g. <FlagsmithProvider serverState={...}>
+            // without an options prop) must flip loadingState to loaded. Guarded on
+            // source===NONE so we never clobber a loaded state already set by
+            // init()/getFlags()/cache paths that also call setState internally.
+            if (this.loadingState.source === FlagSource.NONE && this.flags && Object.keys(this.flags).length > 0) {
+                this.setLoadingState(this._loadedState(null, FlagSource.SERVER));
+            }
         }
     }
 

--- a/test/react.test.tsx
+++ b/test/react.test.tsx
@@ -187,11 +187,6 @@ describe('FlagsmithProvider', () => {
         })
     })
     it('reports a loaded state when hydrated from serverState with no options', async () => {
-        // Reproduces the Next.js/SSR pattern from the docs:
-        //   <FlagsmithProvider flagsmith={...} serverState={flagsmithState}>
-        // No options prop, so flagsmith.init() is not called on the client.
-        // useFlagsmithLoading() must still reflect that flags are loaded,
-        // because the server has already provided them.
         const { flagsmith } = getFlagsmith({})
         render(
             <FlagsmithProvider flagsmith={flagsmith} serverState={defaultState}>

--- a/test/react.test.tsx
+++ b/test/react.test.tsx
@@ -186,6 +186,30 @@ describe('FlagsmithProvider', () => {
             expect(JSON.parse(screen.getByTestId('flags').innerHTML)).toEqual(removeIds(defaultState.flags))
         })
     })
+    it('reports a loaded state when hydrated from serverState with no options', async () => {
+        // Reproduces the Next.js/SSR pattern from the docs:
+        //   <FlagsmithProvider flagsmith={...} serverState={flagsmithState}>
+        // No options prop, so flagsmith.init() is not called on the client.
+        // useFlagsmithLoading() must still reflect that flags are loaded,
+        // because the server has already provided them.
+        const { flagsmith } = getFlagsmith({})
+        render(
+            <FlagsmithProvider flagsmith={flagsmith} serverState={defaultState}>
+                <FlagsmithPage />
+            </FlagsmithProvider>,
+        )
+
+        // Flags are available from serverState immediately.
+        expect(JSON.parse(screen.getByTestId('flags').innerHTML)).toEqual(removeIds(defaultState.flags))
+
+        // Loading state must not be stuck on isLoading/isFetching=true.
+        await waitFor(() => {
+            const loadingState = JSON.parse(screen.getByTestId('loading-state').innerHTML)
+            expect(loadingState.isLoading).toBe(false)
+            expect(loadingState.isFetching).toBe(false)
+            expect(loadingState.error).toBeNull()
+        })
+    })
     it('ignores init response if identify gets called and resolves first', async () => {
         const onChange = jest.fn()
         const { flagsmith, initConfig, mockFetch } = getFlagsmith({ onChange })


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [x] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #389 
- `flagsmith.setState()` now transitions `loadingState` to `{isLoading: false, isFetching: false, source: SERVER}` when called with populated flags while still in `NONE`. 
- `Fixes useFlagsmithLoading()` getting stuck forever under the documented Next.js/SSR pattern (`<FlagsmithProvider serverState={...}>` without an options prop).


## How did you test this code?
- Regression test