### PR TITLE
feat: experimentation events surface (trackEvent, trackExposureEvent, getExperimentFlag)

### DIFF
--- a/event-processor.ts
+++ b/event-processor.ts
@@ -55,7 +55,6 @@ export class EventProcessor {
     private buffer: IEvent[] = [];
     private dedupeKeys: Set<string> = new Set();
     private timer: ReturnType<typeof setInterval> | null = null;
-    private retryTimers: Set<ReturnType<typeof setTimeout>> = new Set();
 
     constructor(opts: EventProcessorOptions) {
         const url = ensureTrailingSlash(opts.eventsApiUrl || DEFAULT_EVENTS_API_URL);
@@ -117,7 +116,7 @@ export class EventProcessor {
         this.stop();
         if (this.flushInterval > 0) {
             this.timer = setInterval(this.flush, this.flushInterval);
-            (this.timer as any)?.unref?.();
+            this.timer?.unref?.();
         }
     }
 
@@ -127,20 +126,6 @@ export class EventProcessor {
             this.timer = null;
         }
         this.flush();
-        this.retryTimers.forEach((t) => clearTimeout(t));
-        this.retryTimers.clear();
-    }
-
-    // Resolves after `ms`, tracking the timer so stop() can cancel a pending retry.
-    private delay(ms: number): Promise<void> {
-        return new Promise((resolve) => {
-            const timer = setTimeout(() => {
-                this.retryTimers.delete(timer);
-                resolve();
-            }, ms);
-            this.retryTimers.add(timer);
-            (timer as any)?.unref?.();
-        });
     }
 
     private postBatch = async (events: IEvent[], attempt: number): Promise<void> => {
@@ -161,7 +146,10 @@ export class EventProcessor {
         } catch (err) {
             if (attempt < 1) {
                 this.log('Events: flush failed, retrying', err);
-                await this.delay(this.retryBackoffMs);
+                await new Promise<void>((resolve) => {
+                    const t = setTimeout(resolve, this.retryBackoffMs);
+                    t?.unref?.();
+                });
                 return this.postBatch(events, attempt + 1);
             }
             this.log('Events: flush failed, dropping batch', err);

--- a/event-processor.ts
+++ b/event-processor.ts
@@ -113,6 +113,8 @@ export class EventProcessor {
     };
 
     start() {
+        // stop() clears any existing timer and flushes; the flush is a no-op
+        // when the buffer is empty, which is the usual case on (re)start.
         this.stop();
         if (this.flushInterval > 0) {
             this.timer = setInterval(this.flush, this.flushInterval);
@@ -125,6 +127,9 @@ export class EventProcessor {
             clearInterval(this.timer);
             this.timer = null;
         }
+        // Best-effort, fire-and-forget: this flush is not awaited, so on rapid
+        // re-init buffered events may be lost. Callers needing a guarantee
+        // (SSR/teardown) should await flushEvents() instead.
         this.flush();
     }
 

--- a/event-processor.ts
+++ b/event-processor.ts
@@ -1,6 +1,7 @@
 import { SDK_VERSION } from './utils/version';
 import { ensureTrailingSlash } from './utils/ensureTrailingSlash';
 import { LikeFetch } from './flagsmith-core';
+import { IFlagsmithValue } from './types';
 
 export const FLAG_EXPOSURE_EVENT = '$flag_exposure';
 export const DEFAULT_EVENTS_API_URL = 'https://events.api.flagsmith.com/';
@@ -12,39 +13,35 @@ export interface IEvent {
     event: string;
     feature_name: string | null;
     identifier: string | null;
-    value: any;
-    traits: Record<string, any> | null;
-    metadata: Record<string, any> | null;
+    value: string | null;
+    traits: Record<string, IFlagsmithValue> | null;
+    metadata: Record<string, unknown> | null;
     timestamp: number;
 }
 
-export interface IEventProcessorConfig {
+export interface EventProcessorOptions {
+    environmentKey: string;
+    fetch: LikeFetch;
     eventsApiUrl?: string;
     maxBuffer?: number;
     flushInterval?: number;
-}
-
-export interface IEventProcessorDeps {
-    environmentKey: string;
-    fetch: LikeFetch;
     log?: (...args: any[]) => void;
     retryBackoffMs?: number;
 }
 
-interface TrackEventArgs {
-    event: string;
+interface EventArgs {
     identifier: string | null;
-    value: string | number | boolean | null;
-    traits: Record<string, any> | null;
+    value: IFlagsmithValue;
+    traits: Record<string, IFlagsmithValue> | null;
     metadata: Record<string, unknown> | null;
 }
 
-interface TrackExposureArgs {
+interface TrackEventArgs extends EventArgs {
+    event: string;
+}
+
+interface TrackExposureArgs extends EventArgs {
     featureName: string;
-    identifier: string | null;
-    value: string | number | boolean | null;
-    traits: Record<string, any> | null;
-    metadata: Record<string, unknown> | null;
 }
 
 export class EventProcessor {
@@ -60,7 +57,7 @@ export class EventProcessor {
     private timer: ReturnType<typeof setInterval> | null = null;
     private retryTimers: Set<ReturnType<typeof setTimeout>> = new Set();
 
-    constructor(opts: IEventProcessorConfig & IEventProcessorDeps) {
+    constructor(opts: EventProcessorOptions) {
         const url = ensureTrailingSlash(opts.eventsApiUrl || DEFAULT_EVENTS_API_URL);
         this.endpoint = `${url}v1/events`;
         this.environmentKey = opts.environmentKey;
@@ -83,8 +80,8 @@ export class EventProcessor {
         event: string,
         feature_name: string | null,
         identifier: string | null,
-        value: string | number | boolean | null,
-        traits: Record<string, any> | null,
+        value: IFlagsmithValue,
+        traits: Record<string, IFlagsmithValue> | null,
         metadata: Record<string, unknown> | null,
         dedupe: boolean,
     ) {
@@ -113,7 +110,7 @@ export class EventProcessor {
         const events = this.buffer;
         this.buffer = [];
         this.dedupeKeys.clear();
-        await this.sendBatch(events, 0);
+        await this.postBatch(events, 0);
     };
 
     start() {
@@ -134,7 +131,19 @@ export class EventProcessor {
         this.retryTimers.clear();
     }
 
-    private sendBatch = async (events: IEvent[], attempt: number): Promise<void> => {
+    // Resolves after `ms`, tracking the timer so stop() can cancel a pending retry.
+    private delay(ms: number): Promise<void> {
+        return new Promise((resolve) => {
+            const timer = setTimeout(() => {
+                this.retryTimers.delete(timer);
+                resolve();
+            }, ms);
+            this.retryTimers.add(timer);
+            (timer as any)?.unref?.();
+        });
+    }
+
+    private postBatch = async (events: IEvent[], attempt: number): Promise<void> => {
         try {
             const res = await this.fetch(this.endpoint, {
                 method: 'POST',
@@ -152,15 +161,8 @@ export class EventProcessor {
         } catch (err) {
             if (attempt < 1) {
                 this.log('Events: flush failed, retrying', err);
-                await new Promise<void>((resolve) => {
-                    const t = setTimeout(() => {
-                        this.retryTimers.delete(t);
-                        resolve();
-                    }, this.retryBackoffMs);
-                    this.retryTimers.add(t);
-                    (t as any)?.unref?.();
-                });
-                return this.sendBatch(events, attempt + 1);
+                await this.delay(this.retryBackoffMs);
+                return this.postBatch(events, attempt + 1);
             }
             this.log('Events: flush failed, dropping batch', err);
         }

--- a/event-processor.ts
+++ b/event-processor.ts
@@ -1,0 +1,168 @@
+import { SDK_VERSION } from './utils/version';
+import { ensureTrailingSlash } from './utils/ensureTrailingSlash';
+import { LikeFetch } from './flagsmith-core';
+
+export const FLAG_EXPOSURE_EVENT = '$flag_exposure';
+export const DEFAULT_EVENTS_API_URL = 'https://events.api.flagsmith.com/';
+const DEFAULT_MAX_BUFFER = 1000;
+const DEFAULT_FLUSH_INTERVAL = 10000;
+const DEFAULT_RETRY_BACKOFF_MS = 1000;
+
+export interface IEvent {
+    event: string;
+    feature_name: string | null;
+    identifier: string | null;
+    value: any;
+    traits: Record<string, any> | null;
+    metadata: Record<string, any> | null;
+    timestamp: number;
+}
+
+export interface IEventProcessorConfig {
+    eventsApiUrl?: string;
+    maxBuffer?: number;
+    flushInterval?: number;
+}
+
+export interface IEventProcessorDeps {
+    environmentKey: string;
+    fetch: LikeFetch;
+    log?: (...args: any[]) => void;
+    retryBackoffMs?: number;
+}
+
+interface TrackEventArgs {
+    event: string;
+    identifier: string | null;
+    value: string | number | boolean | null;
+    traits: Record<string, any> | null;
+    metadata: Record<string, unknown> | null;
+}
+
+interface TrackExposureArgs {
+    featureName: string;
+    identifier: string | null;
+    value: string | number | boolean | null;
+    traits: Record<string, any> | null;
+    metadata: Record<string, unknown> | null;
+}
+
+export class EventProcessor {
+    private endpoint: string;
+    private environmentKey: string;
+    private fetch: LikeFetch;
+    private log: (...args: any[]) => void;
+    private maxBuffer: number;
+    private flushInterval: number;
+    private retryBackoffMs: number;
+    private buffer: IEvent[] = [];
+    private dedupeKeys: Set<string> = new Set();
+    private timer: ReturnType<typeof setInterval> | null = null;
+    private retryTimers: Set<ReturnType<typeof setTimeout>> = new Set();
+
+    constructor(opts: IEventProcessorConfig & IEventProcessorDeps) {
+        const url = ensureTrailingSlash(opts.eventsApiUrl || DEFAULT_EVENTS_API_URL);
+        this.endpoint = `${url}v1/events`;
+        this.environmentKey = opts.environmentKey;
+        this.fetch = opts.fetch;
+        this.log = opts.log || (() => {});
+        this.maxBuffer = opts.maxBuffer ?? DEFAULT_MAX_BUFFER;
+        this.flushInterval = opts.flushInterval ?? DEFAULT_FLUSH_INTERVAL;
+        this.retryBackoffMs = opts.retryBackoffMs ?? DEFAULT_RETRY_BACKOFF_MS;
+    }
+
+    trackEvent(args: TrackEventArgs) {
+        this.bufferEvent(args.event, null, args.identifier, args.value, args.traits, args.metadata, false);
+    }
+
+    trackExposureEvent(args: TrackExposureArgs) {
+        this.bufferEvent(FLAG_EXPOSURE_EVENT, args.featureName, args.identifier, args.value, args.traits, args.metadata, true);
+    }
+
+    private bufferEvent(
+        event: string,
+        feature_name: string | null,
+        identifier: string | null,
+        value: string | number | boolean | null,
+        traits: Record<string, any> | null,
+        metadata: Record<string, unknown> | null,
+        dedupe: boolean,
+    ) {
+        const stringValue = value != null ? String(value) : null;
+        if (dedupe) {
+            const key = JSON.stringify([event, feature_name, identifier, stringValue]);
+            if (this.dedupeKeys.has(key)) return;
+            this.dedupeKeys.add(key);
+        }
+        this.buffer.push({
+            event,
+            feature_name,
+            identifier,
+            value: stringValue,
+            traits,
+            metadata: { ...(metadata || {}), sdk_version: SDK_VERSION },
+            timestamp: Date.now(),
+        });
+        if (this.buffer.length >= this.maxBuffer) {
+            this.flush();
+        }
+    }
+
+    flush = async (): Promise<void> => {
+        if (!this.buffer.length) return;
+        const events = this.buffer;
+        this.buffer = [];
+        this.dedupeKeys.clear();
+        await this.sendBatch(events, 0);
+    };
+
+    start() {
+        this.stop();
+        if (this.flushInterval > 0) {
+            this.timer = setInterval(this.flush, this.flushInterval);
+            (this.timer as any)?.unref?.();
+        }
+    }
+
+    stop() {
+        if (this.timer) {
+            clearInterval(this.timer);
+            this.timer = null;
+        }
+        this.flush();
+        this.retryTimers.forEach((t) => clearTimeout(t));
+        this.retryTimers.clear();
+    }
+
+    private sendBatch = async (events: IEvent[], attempt: number): Promise<void> => {
+        try {
+            const res = await this.fetch(this.endpoint, {
+                method: 'POST',
+                body: JSON.stringify({ events }),
+                headers: {
+                    'Content-Type': 'application/json; charset=utf-8',
+                    'X-Environment-Key': this.environmentKey,
+                    ...(SDK_VERSION ? { 'Flagsmith-SDK-User-Agent': `flagsmith-js-sdk/${SDK_VERSION}` } : {}),
+                },
+            });
+            if (!res.status || res.status < 200 || res.status >= 300) {
+                throw new Error(`Events: unexpected status ${res.status}`);
+            }
+            this.log('Events: flush successful');
+        } catch (err) {
+            if (attempt < 1) {
+                this.log('Events: flush failed, retrying', err);
+                await new Promise<void>((resolve) => {
+                    const t = setTimeout(() => {
+                        this.retryTimers.delete(t);
+                        resolve();
+                    }, this.retryBackoffMs);
+                    this.retryTimers.add(t);
+                    (t as any)?.unref?.();
+                });
+                return this.sendBatch(events, attempt + 1);
+            }
+            this.log('Events: flush failed, dropping batch', err);
+        }
+    };
+}

--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -294,6 +294,11 @@ const Flagsmith = class {
     withTraits?: ITraits|null= null
     cacheOptions = {ttl:0, skipAPI: false, loadStale: false, storageKey: undefined as string|undefined}
     private eventProcessor: EventProcessor | null = null
+    /**
+     * @experimental @internal Whether the events pipeline is enabled
+     * (enableEvents: true was passed to init).
+     */
+    eventsEnabled = false
     async init(config: IInitConfig) {
         if (config.eventProcessorConfig && !config.enableEvents) {
             throw new Error('Flagsmith: eventProcessorConfig requires enableEvents: true.');
@@ -461,6 +466,7 @@ const Flagsmith = class {
                 });
                 this.eventProcessor.start();
             }
+            this.eventsEnabled = !!enableEvents;
 
             //If the user specified default flags emit a changed event immediately
             if (cacheFlags) {

--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -9,6 +9,7 @@ import {
     IFlagsmithFeature,
     IFlagsmithResponse,
     IFlagsmithTrait,
+    IFlagsmithValue,
     IInitConfig,
     ISentryClient,
     IState,
@@ -293,7 +294,6 @@ const Flagsmith = class {
     withTraits?: ITraits|null= null
     cacheOptions = {ttl:0, skipAPI: false, loadStale: false, storageKey: undefined as string|undefined}
     private eventProcessor: EventProcessor | null = null
-    private warnedNoExperimentIdentity = false
     async init(config: IInitConfig) {
         if (config.eventProcessorConfig && !config.enableEvents) {
             throw new Error('Flagsmith: eventProcessorConfig requires enableEvents: true.');
@@ -948,19 +948,9 @@ const Flagsmith = class {
         return this.eventProcessor;
     }
 
-    private resolveEventIdentifier(opts?: { identifier?: string | null }): string | null {
-        if (opts && 'identifier' in opts) return opts.identifier ?? null;
-        return this.evaluationContext.identity?.identifier ?? null;
-    }
-
-    private resolveEventTraits(opts?: { traits?: ITraits }): Record<string, any> | null {
-        const raw = opts && 'traits' in opts ? opts.traits : this.evaluationContext.identity?.traits;
-        return resolveTraitValues(raw as any);
-    }
-
     trackEvent = (event: string, opts?: {
         identifier?: string | null;
-        value?: string | number | boolean | null;
+        value?: IFlagsmithValue;
         traits?: ITraits;
         metadata?: Record<string, unknown>;
     }) => {
@@ -970,25 +960,25 @@ const Flagsmith = class {
         }
         processor.trackEvent({
             event,
-            identifier: this.resolveEventIdentifier(opts),
+            identifier: opts?.identifier ?? this.evaluationContext.identity?.identifier ?? null,
             value: opts?.value ?? null,
-            traits: this.resolveEventTraits(opts),
+            traits: resolveTraitValues(opts?.traits ?? this.evaluationContext.identity?.traits),
             metadata: opts?.metadata ?? null,
         });
     };
 
     trackExposureEvent = (featureName: string, opts?: {
         identifier?: string | null;
-        value?: string | number | boolean | null;
+        value?: IFlagsmithValue;
         traits?: ITraits;
         metadata?: Record<string, unknown>;
     }) => {
         const processor = this.requireEventProcessor();
         processor.trackExposureEvent({
             featureName,
-            identifier: this.resolveEventIdentifier(opts),
+            identifier: opts?.identifier ?? this.evaluationContext.identity?.identifier ?? null,
             value: opts?.value ?? null,
-            traits: this.resolveEventTraits(opts),
+            traits: resolveTraitValues(opts?.traits ?? this.evaluationContext.identity?.traits),
             metadata: opts?.metadata ?? null,
         });
     };
@@ -1001,14 +991,9 @@ const Flagsmith = class {
         const flag = (this.flags && this.flags[key]) || null;
         const identifier = this.evaluationContext.identity?.identifier;
         if (!identifier) {
-            if (!this.warnedNoExperimentIdentity) {
-                this.warnedNoExperimentIdentity = true;
-                console.warn('Flagsmith: getExperimentFlag was called without an identity. Call identify() (optionally with transient: true) before using experiments to record exposures. Falling back to environment flags; no exposure recorded.');
-            }
+            this.log('Flagsmith: getExperimentFlag called without an identity; call identify() (optionally with transient: true) before using experiments to record an exposure. Returning environment flags; no exposure recorded.');
         } else if (this.loadingState.source === FlagSource.SERVER && flag) {
-            this.trackExposureEvent(featureName, {
-                value: flag.value,
-            });
+            this.trackExposureEvent(featureName, { value: flag.value });
         }
         return flag;
     };

--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -961,8 +961,8 @@ const Flagsmith = class {
         metadata?: Record<string, unknown>;
     }) => {
         const processor = this.requireEventProcessor();
-        if (event.startsWith('$') && event !== FLAG_EXPOSURE_EVENT) {
-            throw new Error(`Flagsmith: event name "${event}" uses the reserved "$" prefix but is not a known system event.`);
+        if (event.startsWith('$')) {
+            throw new Error(`Flagsmith: event names starting with "$" are reserved; use trackExposureEvent to record "${FLAG_EXPOSURE_EVENT}".`);
         }
         processor.trackEvent({
             event,

--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -947,24 +947,18 @@ const Flagsmith = class {
         this.updateEventStorage();
     };
 
-    private requireEventProcessor(): EventProcessor {
-        if (!this.eventProcessor) {
-            throw new Error('Flagsmith: events must be enabled (enableEvents: true) to use this method.');
-        }
-        return this.eventProcessor;
-    }
-
     trackEvent = (event: string, opts?: {
         identifier?: string | null;
         value?: IFlagsmithValue;
         traits?: ITraits;
         metadata?: Record<string, unknown>;
     }) => {
-        const processor = this.requireEventProcessor();
+        // No-op when events are disabled, mirroring enableAnalytics: false.
+        if (!this.eventProcessor) return;
         if (event.startsWith('$')) {
             throw new Error(`Flagsmith: event names starting with "$" are reserved; use trackExposureEvent to record "${FLAG_EXPOSURE_EVENT}".`);
         }
-        processor.trackEvent({
+        this.eventProcessor.trackEvent({
             event,
             identifier: opts?.identifier ?? this.evaluationContext.identity?.identifier ?? null,
             value: opts?.value ?? null,
@@ -979,8 +973,9 @@ const Flagsmith = class {
         traits?: ITraits;
         metadata?: Record<string, unknown>;
     }) => {
-        const processor = this.requireEventProcessor();
-        processor.trackExposureEvent({
+        // No-op when events are disabled, mirroring enableAnalytics: false.
+        if (!this.eventProcessor) return;
+        this.eventProcessor.trackExposureEvent({
             featureName,
             identifier: opts?.identifier ?? this.evaluationContext.identity?.identifier ?? null,
             value: opts?.value ?? null,
@@ -992,9 +987,10 @@ const Flagsmith = class {
     flushEvents = (): Promise<void> => this.eventProcessor ? this.eventProcessor.flush() : Promise.resolve();
 
     getExperimentFlag = (featureName: string): IFlagsmithFeature | null => {
-        this.requireEventProcessor();
         const key = featureName.toLowerCase().replace(/ /g, '_');
         const flag = (this.flags && this.flags[key]) || null;
+        // When events are disabled this degrades to a plain flag read.
+        if (!this.eventProcessor) return flag;
         const identifier = this.evaluationContext.identity?.identifier;
         if (!identifier) {
             this.log('Flagsmith: getExperimentFlag called without an identity; call identify() (optionally with transient: true) before using experiments to record an exposure. Returning environment flags; no exposure recorded.');

--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -1001,6 +1001,10 @@ const Flagsmith = class {
             this.log(`Flagsmith: getExperimentFlag called for "${featureName}" which does not exist. No exposure recorded.`);
             return null;
         }
+        if (!flag.enabled) {
+            this.log(`Flagsmith: getExperimentFlag called for "${featureName}" which is disabled. No exposure recorded.`);
+            return flag;
+        }
         if (!flag.variant) {
             this.log(`Flagsmith: getExperimentFlag called for "${featureName}" which has no variant; experiments require a multivariate flag. No exposure recorded.`);
             return flag;

--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -6,6 +6,7 @@ import {
     IDatadogRum,
     IFlags,
     IFlagsmith,
+    IFlagsmithFeature,
     IFlagsmithResponse,
     IFlagsmithTrait,
     IInitConfig,
@@ -23,9 +24,10 @@ import getChanges from './utils/get-changes';
 import angularFetch from './utils/angular-fetch';
 import setDynatraceValue from './utils/set-dynatrace-value';
 import { EvaluationContext } from './evaluation-context';
-import { isTraitEvaluationContext, toEvaluationContext, toTraitEvaluationContextObject } from './utils/types';
+import { isTraitEvaluationContext, resolveTraitValues, toEvaluationContext, toTraitEvaluationContextObject } from './utils/types';
 import { ensureTrailingSlash } from './utils/ensureTrailingSlash';
 import { SDK_VERSION } from './utils/version';
+import { EventProcessor, FLAG_EXPOSURE_EVENT } from './event-processor';
 
 export enum FlagSource {
     "NONE" = "NONE",
@@ -290,7 +292,12 @@ const Flagsmith = class {
     sentryClient: ISentryClient | null = null
     withTraits?: ITraits|null= null
     cacheOptions = {ttl:0, skipAPI: false, loadStale: false, storageKey: undefined as string|undefined}
+    private eventProcessor: EventProcessor | null = null
+    private warnedNoExperimentIdentity = false
     async init(config: IInitConfig) {
+        if (config.eventProcessorConfig && !config.enableEvents) {
+            throw new Error('Flagsmith: eventProcessorConfig requires enableEvents: true.');
+        }
         const evaluationContext = toEvaluationContext(config.evaluationContext || this.evaluationContext);
         try {
             const {
@@ -308,6 +315,8 @@ const Flagsmith = class {
                 enableDynatrace,
                 enableLogs,
                 environmentID,
+                enableEvents,
+                eventProcessorConfig,
                 eventSourceUrl= "https://realtime.flagsmith.com/",
                 fetch: fetchImplementation,
                 headers,
@@ -439,6 +448,18 @@ const Flagsmith = class {
                         }
                     });
                 }
+            }
+
+            this.eventProcessor?.stop();
+            this.eventProcessor = null;
+            if (enableEvents) {
+                this.eventProcessor = new EventProcessor({
+                    ...(eventProcessorConfig || {}),
+                    environmentKey: this.evaluationContext.environment!.apiKey,
+                    fetch: _fetch,
+                    log: (...args: any[]) => this.log(...args),
+                });
+                this.eventProcessor.start();
             }
 
             //If the user specified default flags emit a changed event immediately
@@ -916,7 +937,80 @@ const Flagsmith = class {
             }
             this.evaluationEvent[this.evaluationContext.environment.apiKey][key] += 1;
         }
+
         this.updateEventStorage();
+    };
+
+    private requireEventProcessor(): EventProcessor {
+        if (!this.eventProcessor) {
+            throw new Error('Flagsmith: events must be enabled (enableEvents: true) to use this method.');
+        }
+        return this.eventProcessor;
+    }
+
+    private resolveEventIdentifier(opts?: { identifier?: string | null }): string | null {
+        if (opts && 'identifier' in opts) return opts.identifier ?? null;
+        return this.evaluationContext.identity?.identifier ?? null;
+    }
+
+    private resolveEventTraits(opts?: { traits?: ITraits }): Record<string, any> | null {
+        const raw = opts && 'traits' in opts ? opts.traits : this.evaluationContext.identity?.traits;
+        return resolveTraitValues(raw as any);
+    }
+
+    trackEvent = (event: string, opts?: {
+        identifier?: string | null;
+        value?: string | number | boolean | null;
+        traits?: ITraits;
+        metadata?: Record<string, unknown>;
+    }) => {
+        const processor = this.requireEventProcessor();
+        if (event.startsWith('$') && event !== FLAG_EXPOSURE_EVENT) {
+            throw new Error(`Flagsmith: event name "${event}" uses the reserved "$" prefix but is not a known system event.`);
+        }
+        processor.trackEvent({
+            event,
+            identifier: this.resolveEventIdentifier(opts),
+            value: opts?.value ?? null,
+            traits: this.resolveEventTraits(opts),
+            metadata: opts?.metadata ?? null,
+        });
+    };
+
+    trackExposureEvent = (featureName: string, opts?: {
+        identifier?: string | null;
+        value?: string | number | boolean | null;
+        traits?: ITraits;
+        metadata?: Record<string, unknown>;
+    }) => {
+        const processor = this.requireEventProcessor();
+        processor.trackExposureEvent({
+            featureName,
+            identifier: this.resolveEventIdentifier(opts),
+            value: opts?.value ?? null,
+            traits: this.resolveEventTraits(opts),
+            metadata: opts?.metadata ?? null,
+        });
+    };
+
+    flushEvents = (): Promise<void> => this.eventProcessor ? this.eventProcessor.flush() : Promise.resolve();
+
+    getExperimentFlag = (featureName: string): IFlagsmithFeature | null => {
+        this.requireEventProcessor();
+        const key = featureName.toLowerCase().replace(/ /g, '_');
+        const flag = (this.flags && this.flags[key]) || null;
+        const identifier = this.evaluationContext.identity?.identifier;
+        if (!identifier) {
+            if (!this.warnedNoExperimentIdentity) {
+                this.warnedNoExperimentIdentity = true;
+                console.warn('Flagsmith: getExperimentFlag was called without an identity. Call identify() (optionally with transient: true) before using experiments to record exposures. Falling back to environment flags; no exposure recorded.');
+            }
+        } else if (this.loadingState.source === FlagSource.SERVER && flag) {
+            this.trackExposureEvent(featureName, {
+                value: flag.value,
+            });
+        }
+        return flag;
     };
 
     private setLoadingState(loadingState: LoadingState) {

--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -122,7 +122,8 @@ const Flagsmith = class {
                 flags[feature.feature.name.toLowerCase().replace(/ /g, '_')] = {
                     id: feature.feature.id,
                     enabled: feature.enabled,
-                    value: feature.feature_state_value
+                    value: feature.feature_state_value,
+                    ...(feature.variant ? { variant: feature.variant } : {}),
                 };
             });
             traits.forEach(trait => {
@@ -994,9 +995,20 @@ const Flagsmith = class {
         const identifier = this.evaluationContext.identity?.identifier;
         if (!identifier) {
             this.log('Flagsmith: getExperimentFlag called without an identity; call identify() (optionally with transient: true) before using experiments to record an exposure. Returning environment flags; no exposure recorded.');
-        } else if (this.loadingState.source === FlagSource.SERVER && flag) {
-            this.trackExposureEvent(featureName, { value: flag.value });
+            return flag;
         }
+        if (!flag) {
+            this.log(`Flagsmith: getExperimentFlag called for "${featureName}" which does not exist. No exposure recorded.`);
+            return null;
+        }
+        if (!flag.variant) {
+            this.log(`Flagsmith: getExperimentFlag called for "${featureName}" which has no variant; experiments require a multivariate flag. No exposure recorded.`);
+            return flag;
+        }
+        if (this.loadingState.source !== FlagSource.SERVER) {
+            return flag;
+        }
+        this.trackExposureEvent(featureName, { value: flag.variant });
         return flag;
     };
 

--- a/react.d.ts
+++ b/react.d.ts
@@ -27,6 +27,13 @@ export declare function useFlags<
     F extends string | Record<string, any>,
     T extends string = string
 >(_flags: readonly (F | keyof F)[], _traits?: readonly T[]): UseFlagsReturn<F, T>;
+/**
+ * Resolve an experiment flag for the identified user and record one
+ * `$flag_exposure` event. Returns the flag (or null) and never throws when
+ * events are disabled.
+ * @experimental @internal
+ */
+export declare function useExperiment(featureName: string): IFlagsmithFeature | null;
 export declare const useFlagsmith: <F extends string | Record<string, any>,
     T extends string = string>() => IFlagsmith<F, T>;
 export declare const useFlagsmithLoading: () => LoadingState | undefined;

--- a/react.tsx
+++ b/react.tsx
@@ -86,7 +86,10 @@ const getRenderKey = (flagsmith: IFlagsmith, flags: string[], traits: string[] =
 
 const getExperimentRenderKey = (flagsmith: IFlagsmith | null, key: string): string => {
     const flag = flagsmith?.getAllFlags()?.[key]
-    return `${flag?.value}${flag?.enabled}`
+    const identifier = flagsmith?.getContext().identity?.identifier ?? null
+    // Identity is part of the key so that switching identity re-renders (and
+    // re-fires the exposure) even when the resolved value is unchanged.
+    return `${identifier}|${flag?.value}|${flag?.enabled}`
 }
 
 export function useFlagsmithLoading() {
@@ -227,12 +230,12 @@ export function useExperiment(featureName: string): IFlagsmithFeature | null {
     }, [flagsmith, key])
 
     const flag = (flagsmith?.getAllFlags()?.[key] as IFlagsmithFeature | undefined) ?? null
+    const identifier = flagsmith?.getContext().identity?.identifier ?? null
 
     useEffect(() => {
         if (!flagsmith?.eventsEnabled || !flag) {
             return
         }
-        const identifier = flagsmith.getContext().identity?.identifier ?? null
         const exposureKey = `${key}:${identifier}:${flag.value}`
         if (lastExposureKey.current === exposureKey) {
             return
@@ -240,7 +243,7 @@ export function useExperiment(featureName: string): IFlagsmithFeature | null {
         lastExposureKey.current = exposureKey
         flagsmith.getExperimentFlag(featureName)
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [flagsmith, featureName, key, flag?.value, flag?.enabled])
+    }, [flagsmith, featureName, key, identifier, flag?.value, flag?.enabled])
 
     return flag
 }

--- a/react.tsx
+++ b/react.tsx
@@ -84,6 +84,11 @@ const getRenderKey = (flagsmith: IFlagsmith, flags: string[], traits: string[] =
         .join(',')
 }
 
+const getExperimentRenderKey = (flagsmith: IFlagsmith | null, key: string): string => {
+    const flag = flagsmith?.getAllFlags()?.[key]
+    return `${flag?.value}${flag?.enabled}`
+}
+
 export function useFlagsmithLoading() {
     const flagsmith = useContext(FlagsmithContext)
     const [loadingState, setLoadingState] = useState(flagsmith?.loadingState)
@@ -187,6 +192,57 @@ export function useFlags<F extends string | Record<string, any>, T extends strin
     }, [renderRef])
 
     return res as UseFlagsReturn<F, T>
+}
+
+/**
+ * Resolve an experiment flag for the currently identified user and record a
+ * single `$flag_exposure` event as a side-effect. Re-renders when the flag's
+ * value or enabled state changes. When events are disabled (enableEvents is
+ * not set) the flag is still returned but no exposure is recorded.
+ *
+ * Exposures are gated three ways: the effect only runs when the flag value,
+ * identity, feature or source change; a ref guard prevents duplicate fires for
+ * the same (feature, identifier, value); and the core EventProcessor dedupes
+ * within each flush window. Frequent re-renders therefore never amplify into
+ * extra events.
+ *
+ * @experimental @internal
+ */
+export function useExperiment(featureName: string): IFlagsmithFeature | null {
+    const flagsmith = useContext(FlagsmithContext)
+    const key = featureName.toLowerCase().replace(/ /g, '_')
+    const lastExposureKey = useRef<string | null>(null)
+    const [, setRenderKey] = useState<string>(() => getExperimentRenderKey(flagsmith, key))
+
+    useEffect(() => {
+        const listener = () => {
+            const next = getExperimentRenderKey(flagsmith, key)
+            setRenderKey((prev) => (prev !== next ? next : prev))
+        }
+        const off = events.on('event', listener)
+        listener() // capture any change between first render and subscription
+        return () => {
+            off()
+        }
+    }, [flagsmith, key])
+
+    const flag = (flagsmith?.getAllFlags()?.[key] as IFlagsmithFeature | undefined) ?? null
+
+    useEffect(() => {
+        if (!flagsmith?.eventsEnabled || !flag) {
+            return
+        }
+        const identifier = flagsmith.getContext().identity?.identifier ?? null
+        const exposureKey = `${key}:${identifier}:${flag.value}`
+        if (lastExposureKey.current === exposureKey) {
+            return
+        }
+        lastExposureKey.current = exposureKey
+        flagsmith.getExperimentFlag(featureName)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [flagsmith, featureName, key, flag?.value, flag?.enabled])
+
+    return flag
 }
 
 export function useFlagsmith<F extends string | Record<string, any>, T extends string = string>() {

--- a/react.tsx
+++ b/react.tsx
@@ -75,10 +75,12 @@ const flagsAsArray = (_flags: any): string[] => {
     throw new Error('Flagsmith: please supply an array of strings or a single string of flag keys to useFlags')
 }
 
+const normalizeFlagKey = (key: string) => key.toLowerCase().replace(/ /g, '_')
+
 const getRenderKey = (flagsmith: IFlagsmith, flags: string[], traits: string[] = []) => {
     return flags
         .map((k) => {
-            return `${flagsmith.getValue(k)}${flagsmith.hasFeature(k)}`
+            return `${flagsmith.getValue(k)}${flagsmith.hasFeature(k)}${flagsmith.getAllFlags()?.[normalizeFlagKey(k)]?.variant}`
         })
         .concat(traits.map((t) => `${flagsmith.getTrait(t)}`))
         .join(',')
@@ -89,7 +91,7 @@ const getExperimentRenderKey = (flagsmith: IFlagsmith | null, key: string): stri
     const identifier = flagsmith?.getContext().identity?.identifier ?? null
     // Identity is part of the key so that switching identity re-renders (and
     // re-fires the exposure) even when the resolved value is unchanged.
-    return `${identifier}|${flag?.value}|${flag?.enabled}`
+    return `${identifier}|${flag?.value}|${flag?.enabled}|${flag?.variant}`
 }
 
 export function useFlagsmithLoading() {
@@ -181,9 +183,11 @@ export function useFlags<F extends string | Record<string, any>, T extends strin
         const res: any = {}
         flags
             .map((k) => {
+                const variant = flagsmith!.getAllFlags()?.[normalizeFlagKey(k)]?.variant
                 res[k] = {
                     enabled: flagsmith!.hasFeature(k),
                     value: flagsmith!.getValue(k),
+                    ...(variant != null ? { variant } : {}),
                 }
             })
             .concat(
@@ -204,16 +208,16 @@ export function useFlags<F extends string | Record<string, any>, T extends strin
  * not set) the flag is still returned but no exposure is recorded.
  *
  * Exposures are gated three ways: the effect only runs when the flag value,
- * identity, feature or source change; a ref guard prevents duplicate fires for
- * the same (feature, identifier, value); and the core EventProcessor dedupes
- * within each flush window. Frequent re-renders therefore never amplify into
- * extra events.
+ * variant, identity, feature or source change; a ref guard prevents duplicate
+ * fires for the same (feature, identifier, value, variant); and the core
+ * EventProcessor dedupes within each flush window. Frequent re-renders
+ * therefore never amplify into extra events.
  *
  * @experimental @internal
  */
 export function useExperiment(featureName: string): IFlagsmithFeature | null {
     const flagsmith = useContext(FlagsmithContext)
-    const key = featureName.toLowerCase().replace(/ /g, '_')
+    const key = normalizeFlagKey(featureName)
     const lastExposureKey = useRef<string | null>(null)
     const [, setRenderKey] = useState<string>(() => getExperimentRenderKey(flagsmith, key))
 
@@ -236,14 +240,14 @@ export function useExperiment(featureName: string): IFlagsmithFeature | null {
         if (!flagsmith?.eventsEnabled || !flag) {
             return
         }
-        const exposureKey = `${key}:${identifier}:${flag.value}`
+        const exposureKey = `${key}:${identifier}:${flag.value}:${flag.variant}`
         if (lastExposureKey.current === exposureKey) {
             return
         }
         lastExposureKey.current = exposureKey
         flagsmith.getExperimentFlag(featureName)
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [flagsmith, featureName, key, identifier, flag?.value, flag?.enabled])
+    }, [flagsmith, featureName, key, identifier, flag?.value, flag?.enabled, flag?.variant])
 
     return flag
 }

--- a/test/data/identities_test_experiment_identity.json
+++ b/test/data/identities_test_experiment_identity.json
@@ -1,0 +1,25 @@
+{
+    "identifier": "test_experiment_identity",
+    "flags": [
+        {
+            "feature": {
+                "id": 1804,
+                "name": "hero",
+                "type": "STANDARD"
+            },
+            "enabled": true,
+            "feature_state_value": "https://s3-us-west-2.amazonaws.com/com.uppercut.hero-images/assets/0466/comps/466_03314.jpg"
+        },
+        {
+            "feature": {
+                "id": 6149,
+                "name": "font_size",
+                "type": "MULTIVARIATE"
+            },
+            "enabled": true,
+            "feature_state_value": 16,
+            "variant": "control"
+        }
+    ],
+    "traits": []
+}

--- a/test/data/identities_test_experiment_identity.json
+++ b/test/data/identities_test_experiment_identity.json
@@ -19,6 +19,16 @@
             "enabled": true,
             "feature_state_value": 16,
             "variant": "control"
+        },
+        {
+            "feature": {
+                "id": 80321,
+                "name": "disabled_experiment",
+                "type": "MULTIVARIATE"
+            },
+            "enabled": false,
+            "feature_state_value": null,
+            "variant": "control"
         }
     ],
     "traits": []

--- a/test/event-processor.test.ts
+++ b/test/event-processor.test.ts
@@ -1,0 +1,190 @@
+import { EventProcessor, FLAG_EXPOSURE_EVENT } from '../event-processor';
+import { SDK_VERSION } from '../utils/version';
+
+function makeProcessor(overrides: any = {}) {
+    const mockFetch = jest.fn(async () => ({ status: 202, text: async () => '' }));
+    const processor = new EventProcessor({
+        environmentKey: 'env_key_1',
+        fetch: mockFetch as any,
+        flushInterval: 60000,
+        ...overrides,
+    });
+    return { processor, mockFetch };
+}
+
+describe('EventProcessor dedupe', () => {
+    test('collapses identical exposures within a window', () => {
+        const { processor } = makeProcessor();
+        const args = { featureName: 'dark_mode', identifier: 'u1', value: 'control', traits: null, metadata: null };
+        processor.trackExposureEvent(args);
+        processor.trackExposureEvent(args);
+        processor.trackExposureEvent(args);
+        // @ts-ignore test access
+        expect(processor.buffer).toHaveLength(1);
+    });
+
+    test('keeps exposures with distinct value', () => {
+        const { processor } = makeProcessor();
+        processor.trackExposureEvent({ featureName: 'dark_mode', identifier: 'u1', value: 'control', traits: null, metadata: null });
+        processor.trackExposureEvent({ featureName: 'dark_mode', identifier: 'u1', value: 'variant', traits: null, metadata: null });
+        // @ts-ignore test access
+        expect(processor.buffer).toHaveLength(2);
+    });
+
+    test('never dedupes custom events', () => {
+        const { processor } = makeProcessor();
+        const args = { event: 'purchase', identifier: 'u1', value: 99, traits: null, metadata: null };
+        processor.trackEvent(args);
+        processor.trackEvent(args);
+        // @ts-ignore test access
+        expect(processor.buffer).toHaveLength(2);
+    });
+});
+
+describe('EventProcessor buffering', () => {
+    test('trackEvent buffers a custom event in wire shape', () => {
+        const { processor } = makeProcessor();
+        processor.trackEvent({
+            event: 'purchase',
+            identifier: 'user_42',
+            value: 99.5,
+            traits: { plan: 'premium' },
+            metadata: { source: 'web' },
+        });
+        // @ts-ignore test access
+        const buf = processor.buffer;
+        expect(buf).toHaveLength(1);
+        expect(buf[0]).toEqual(expect.objectContaining({
+            event: 'purchase',
+            feature_name: null,
+            identifier: 'user_42',
+            value: '99.5',
+            traits: { plan: 'premium' },
+        }));
+        expect(buf[0].metadata).toEqual(expect.objectContaining({ source: 'web', sdk_version: SDK_VERSION }));
+        expect(buf[0].timestamp).toEqual(expect.any(Number));
+    });
+
+    test('trackExposureEvent buffers a $flag_exposure with feature_name', () => {
+        const { processor } = makeProcessor();
+        processor.trackExposureEvent({
+            featureName: 'dark_mode',
+            identifier: 'user_42',
+            value: 'control',
+            traits: null,
+            metadata: null,
+        });
+        // @ts-ignore test access
+        const buf = processor.buffer;
+        expect(buf[0]).toEqual(expect.objectContaining({
+            event: FLAG_EXPOSURE_EVENT,
+            feature_name: 'dark_mode',
+            value: 'control',
+            traits: null,
+        }));
+        expect(buf[0].metadata).toEqual(expect.objectContaining({ sdk_version: SDK_VERSION }));
+    });
+});
+
+describe('EventProcessor flush', () => {
+    test('drains buffer and POSTs to /v1/events with headers', async () => {
+        const { processor, mockFetch } = makeProcessor({ eventsApiUrl: 'https://events.test/' });
+        processor.trackEvent({ event: 'purchase', identifier: 'u1', value: 1, traits: null, metadata: null });
+        await processor.flush();
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        const call = mockFetch.mock.calls[0] as unknown as [string, any];
+        const [url, opts] = call;
+        expect(url).toBe('https://events.test/v1/events');
+        expect(opts.method).toBe('POST');
+        expect(opts.headers['X-Environment-Key']).toBe('env_key_1');
+        expect(opts.headers['Content-Type']).toBe('application/json; charset=utf-8');
+        expect(opts.headers['Flagsmith-SDK-User-Agent']).toMatch(/^flagsmith-js-sdk\//);
+        const body = JSON.parse(opts.body);
+        expect(body).toEqual({ events: expect.any(Array) });
+        expect(body.events).toHaveLength(1);
+
+        // @ts-ignore test access — buffer emptied
+        expect(processor.buffer).toHaveLength(0);
+    });
+
+    test('flush on empty buffer is a no-op', async () => {
+        const { processor, mockFetch } = makeProcessor();
+        await processor.flush();
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    test('flush clears the dedupe window', async () => {
+        const { processor } = makeProcessor();
+        const args = { featureName: 'f', identifier: 'u1', value: 'a', traits: null, metadata: null };
+        processor.trackExposureEvent(args);
+        await processor.flush();
+        processor.trackExposureEvent(args); // same key, but window was cleared
+        // @ts-ignore test access
+        expect(processor.buffer).toHaveLength(1);
+    });
+
+    test('auto-flushes when buffer reaches maxBuffer', () => {
+        const { processor, mockFetch } = makeProcessor({ maxBuffer: 2 });
+        processor.trackEvent({ event: 'a', identifier: null, value: null, traits: null, metadata: null });
+        expect(mockFetch).not.toHaveBeenCalled();
+        processor.trackEvent({ event: 'b', identifier: null, value: null, traits: null, metadata: null });
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('EventProcessor lifecycle and retry', () => {
+    test('start arms a timer that flushes; stop clears it', () => {
+        jest.useFakeTimers();
+        try {
+            const { processor, mockFetch } = makeProcessor({ flushInterval: 5000 });
+            processor.start();
+            processor.trackEvent({ event: 'a', identifier: null, value: null, traits: null, metadata: null });
+            expect(mockFetch).not.toHaveBeenCalled();
+            jest.advanceTimersByTime(5000);
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+            processor.stop();
+            processor.trackEvent({ event: 'b', identifier: null, value: null, traits: null, metadata: null });
+            jest.advanceTimersByTime(5000);
+            expect(mockFetch).toHaveBeenCalledTimes(1); // no further flush after stop
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    test('stop flushes any buffered events', async () => {
+        const { processor, mockFetch } = makeProcessor({ flushInterval: 60000 });
+        processor.start();
+        processor.trackEvent({ event: 'a', identifier: null, value: null, traits: null, metadata: null });
+        expect(mockFetch).not.toHaveBeenCalled();
+        processor.stop();
+        await Promise.resolve();
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    test('retries once then drops; buffer stays untouched by a failing batch', async () => {
+        const mockFetch = jest.fn(async () => ({ status: 500, text: async () => 'err' }));
+        const processor = new EventProcessor({
+            environmentKey: 'env_key_1',
+            fetch: mockFetch as any,
+            flushInterval: 60000,
+            retryBackoffMs: 0,
+        });
+        processor.trackEvent({ event: 'a', identifier: null, value: null, traits: null, metadata: null });
+        await processor.flush();
+
+        // 1 initial + 1 retry = 2 attempts, then dropped
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+        // buffer was drained on flush and a failed batch never re-enters it
+        // @ts-ignore test access
+        expect(processor.buffer).toHaveLength(0);
+
+        // processor keeps working: a new event buffers and flushes normally
+        const okFetch = jest.fn(async () => ({ status: 202, text: async () => '' }));
+        // @ts-ignore swap fetch for the recovery assertion
+        processor.fetch = okFetch;
+        processor.trackEvent({ event: 'b', identifier: null, value: null, traits: null, metadata: null });
+        await processor.flush();
+        expect(okFetch).toHaveBeenCalledTimes(1);
+    });
+});

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,4 +1,4 @@
-import { getFlagsmith, environmentID, testIdentity } from './test-constants';
+import { getFlagsmith, environmentID, testIdentity, experimentIdentity } from './test-constants';
 import { FLAG_EXPOSURE_EVENT } from '../event-processor';
 
 const eventsUrl = 'https://events.test/';
@@ -101,11 +101,11 @@ describe('trackEvent', () => {
 
 describe('getExperimentFlag', () => {
     test('returns the flag and fires one $flag_exposure when identified and source is SERVER', async () => {
-        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: testIdentity }));
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: experimentIdentity }));
         await flagsmith.init(initConfig); // fetches identity flags -> source SERVER
 
         const flag = flagsmith.getExperimentFlag('font_size');
-        expect(flag).toEqual(expect.objectContaining({ enabled: true, value: 16 }));
+        expect(flag).toEqual(expect.objectContaining({ enabled: true, value: 16, variant: 'control' }));
 
         await flagsmith.flushEvents();
         const events = JSON.parse(eventCalls(mockFetch)[0][1].body).events;
@@ -113,8 +113,8 @@ describe('getExperimentFlag', () => {
         expect(exposures).toHaveLength(1);
         expect(exposures[0]).toEqual(expect.objectContaining({
             feature_name: 'font_size',
-            identifier: testIdentity,
-            value: '16',
+            identifier: experimentIdentity,
+            value: 'control',
         }));
     });
 
@@ -154,7 +154,7 @@ describe('getExperimentFlag', () => {
     });
 
     test('repeated calls collapse to a single exposure within the window', async () => {
-        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: testIdentity }));
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: experimentIdentity }));
         await flagsmith.init(initConfig);
 
         flagsmith.getExperimentFlag('font_size');

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -160,3 +160,17 @@ describe('getExperimentFlag', () => {
         expect(events.filter((e: any) => e.event === FLAG_EXPOSURE_EVENT)).toHaveLength(1);
     });
 });
+
+describe('eventsEnabled', () => {
+    test('is false when events are not enabled', async () => {
+        const { flagsmith, initConfig } = getFlagsmith();
+        await flagsmith.init(initConfig);
+        expect(flagsmith.eventsEnabled).toBe(false);
+    });
+
+    test('is true when enableEvents is set', async () => {
+        const { flagsmith, initConfig } = getFlagsmith(eventsConfig());
+        await flagsmith.init(initConfig);
+        expect(flagsmith.eventsEnabled).toBe(true);
+    });
+});

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -43,6 +43,7 @@ describe('events gate', () => {
         });
         await flagsmith.init(initConfig);
         expect(() => flagsmith.trackEvent('$custom')).toThrow(/reserved/i);
+        expect(() => flagsmith.trackEvent('$flag_exposure')).toThrow(/reserved/i);
     });
 });
 

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -81,15 +81,15 @@ describe('trackEvent', () => {
         expect(event).toHaveProperty('traits');
     });
 
-    test('explicit identifier: null overrides context (anonymous)', async () => {
+    test('explicit identifier overrides the current context', async () => {
         const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: testIdentity }));
         await flagsmith.init(initConfig);
 
-        flagsmith.trackEvent('purchase', { identifier: null });
+        flagsmith.trackEvent('purchase', { identifier: 'other_user' });
         await flagsmith.flushEvents();
 
         const event = JSON.parse(eventCalls(mockFetch)[0][1].body).events[0];
-        expect(event.identifier).toBeNull();
+        expect(event.identifier).toBe('other_user');
     });
 });
 
@@ -112,26 +112,15 @@ describe('getExperimentFlag', () => {
         }));
     });
 
-    test('skips exposure (and warns) when there is no identity, still returns the flag', async () => {
-        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-        try {
-            const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig());
-            await flagsmith.init(initConfig); // anonymous, env flags -> source SERVER, no identity
+    test('skips exposure when there is no identity, still returns the flag', async () => {
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig());
+        await flagsmith.init(initConfig); // anonymous, env flags -> source SERVER, no identity
 
-            const flag = flagsmith.getExperimentFlag('font_size');
-            expect(flag).toEqual(expect.objectContaining({ enabled: true, value: 16 }));
+        const flag = flagsmith.getExperimentFlag('font_size');
+        expect(flag).toEqual(expect.objectContaining({ enabled: true, value: 16 }));
 
-            await flagsmith.flushEvents();
-            expect(eventCalls(mockFetch)).toHaveLength(0);
-            expect(warnSpy).toHaveBeenCalledTimes(1);
-            expect(warnSpy.mock.calls[0][0]).toMatch(/without an identity/i);
-
-            // warning is emitted at most once
-            flagsmith.getExperimentFlag('font_size');
-            expect(warnSpy).toHaveBeenCalledTimes(1);
-        } finally {
-            warnSpy.mockRestore();
-        }
+        await flagsmith.flushEvents();
+        expect(eventCalls(mockFetch)).toHaveLength(0);
     });
 
     test('skips exposure for default flags (identified but source !== SERVER)', async () => {

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -144,6 +144,17 @@ describe('getExperimentFlag', () => {
         expect(eventCalls(mockFetch)).toHaveLength(0);
     });
 
+    test('skips exposure for a disabled flag even when it has a variant, still returns it', async () => {
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: experimentIdentity }));
+        await flagsmith.init(initConfig); // identified, source SERVER
+
+        const flag = flagsmith.getExperimentFlag('disabled_experiment');
+        expect(flag).toEqual(expect.objectContaining({ enabled: false, variant: 'control' }));
+
+        await flagsmith.flushEvents();
+        expect(eventCalls(mockFetch)).toHaveLength(0);
+    });
+
     test('skips exposure and returns null for an absent feature', async () => {
         const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: testIdentity }));
         await flagsmith.init(initConfig);

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,0 +1,173 @@
+import { getFlagsmith, environmentID, testIdentity } from './test-constants';
+import { FLAG_EXPOSURE_EVENT } from '../event-processor';
+
+const eventsUrl = 'https://events.test/';
+
+function eventsConfig(extra: any = {}) {
+    return {
+        enableEvents: true,
+        eventProcessorConfig: { eventsApiUrl: eventsUrl, flushInterval: 60000 },
+        ...extra,
+    };
+}
+
+function eventCalls(mockFetch: jest.Mock) {
+    return mockFetch.mock.calls.filter(([url]: [string]) => url.includes('/v1/events'));
+}
+
+describe('events gate', () => {
+    test('trackEvent throws when events are not enabled', async () => {
+        const { flagsmith, initConfig } = getFlagsmith();
+        await flagsmith.init(initConfig);
+        expect(() => flagsmith.trackEvent('purchase')).toThrow(/events must be enabled/i);
+    });
+
+    test('trackExposureEvent and getExperimentFlag throw when not enabled', async () => {
+        const { flagsmith, initConfig } = getFlagsmith();
+        await flagsmith.init(initConfig);
+        expect(() => flagsmith.trackExposureEvent('f')).toThrow(/events must be enabled/i);
+        expect(() => flagsmith.getExperimentFlag('f')).toThrow(/events must be enabled/i);
+    });
+
+    test('eventProcessorConfig without enableEvents throws at init', async () => {
+        const { flagsmith, initConfig } = getFlagsmith({
+            eventProcessorConfig: { eventsApiUrl: eventsUrl },
+        });
+        await expect(flagsmith.init(initConfig)).rejects.toThrow(/requires enableEvents/i);
+    });
+
+    test('trackEvent rejects reserved $-prefixed event names', async () => {
+        const { flagsmith, initConfig } = getFlagsmith({
+            enableEvents: true,
+            eventProcessorConfig: { eventsApiUrl: 'https://events.test/', flushInterval: 60000 },
+        });
+        await flagsmith.init(initConfig);
+        expect(() => flagsmith.trackEvent('$custom')).toThrow(/reserved/i);
+    });
+});
+
+describe('trackEvent', () => {
+    test('sends a custom event with correct wire shape and headers', async () => {
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: testIdentity }));
+        await flagsmith.init(initConfig);
+
+        flagsmith.trackEvent('purchase', { value: 99.5, metadata: { source: 'web' } });
+        await flagsmith.flushEvents();
+
+        const calls = eventCalls(mockFetch);
+        expect(calls).toHaveLength(1);
+        const [url, opts] = calls[0];
+        expect(url).toBe('https://events.test/v1/events');
+        expect(opts.headers['X-Environment-Key']).toBe(environmentID);
+        const event = JSON.parse(opts.body).events[0];
+        expect(event).toEqual(expect.objectContaining({
+            event: 'purchase',
+            feature_name: null,
+            identifier: testIdentity,
+            value: '99.5',
+        }));
+        expect(event.metadata).toEqual(expect.objectContaining({ source: 'web' }));
+    });
+
+    test('defaults identifier and traits to the current context', async () => {
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: testIdentity }));
+        await flagsmith.init(initConfig);
+
+        flagsmith.trackEvent('purchase');
+        await flagsmith.flushEvents();
+
+        const event = JSON.parse(eventCalls(mockFetch)[0][1].body).events[0];
+        expect(event.identifier).toBe(testIdentity);
+        expect(event).toHaveProperty('traits');
+    });
+
+    test('explicit identifier: null overrides context (anonymous)', async () => {
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: testIdentity }));
+        await flagsmith.init(initConfig);
+
+        flagsmith.trackEvent('purchase', { identifier: null });
+        await flagsmith.flushEvents();
+
+        const event = JSON.parse(eventCalls(mockFetch)[0][1].body).events[0];
+        expect(event.identifier).toBeNull();
+    });
+});
+
+describe('getExperimentFlag', () => {
+    test('returns the flag and fires one $flag_exposure when identified and source is SERVER', async () => {
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: testIdentity }));
+        await flagsmith.init(initConfig); // fetches identity flags -> source SERVER
+
+        const flag = flagsmith.getExperimentFlag('font_size');
+        expect(flag).toEqual(expect.objectContaining({ enabled: true, value: 16 }));
+
+        await flagsmith.flushEvents();
+        const events = JSON.parse(eventCalls(mockFetch)[0][1].body).events;
+        const exposures = events.filter((e: any) => e.event === FLAG_EXPOSURE_EVENT);
+        expect(exposures).toHaveLength(1);
+        expect(exposures[0]).toEqual(expect.objectContaining({
+            feature_name: 'font_size',
+            identifier: testIdentity,
+            value: '16',
+        }));
+    });
+
+    test('skips exposure (and warns) when there is no identity, still returns the flag', async () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig());
+            await flagsmith.init(initConfig); // anonymous, env flags -> source SERVER, no identity
+
+            const flag = flagsmith.getExperimentFlag('font_size');
+            expect(flag).toEqual(expect.objectContaining({ enabled: true, value: 16 }));
+
+            await flagsmith.flushEvents();
+            expect(eventCalls(mockFetch)).toHaveLength(0);
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            expect(warnSpy.mock.calls[0][0]).toMatch(/without an identity/i);
+
+            // warning is emitted at most once
+            flagsmith.getExperimentFlag('font_size');
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+        } finally {
+            warnSpy.mockRestore();
+        }
+    });
+
+    test('skips exposure for default flags (identified but source !== SERVER)', async () => {
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({
+            identity: testIdentity,
+            preventFetch: true,
+            defaultFlags: { font_size: { enabled: true, value: 12 } },
+        }));
+        await flagsmith.init(initConfig); // no fetch -> source DEFAULT_FLAGS
+
+        const flag = flagsmith.getExperimentFlag('font_size');
+        expect(flag).toEqual(expect.objectContaining({ value: 12 }));
+
+        await flagsmith.flushEvents();
+        expect(eventCalls(mockFetch)).toHaveLength(0);
+    });
+
+    test('skips exposure and returns null for an absent feature', async () => {
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: testIdentity }));
+        await flagsmith.init(initConfig);
+
+        expect(flagsmith.getExperimentFlag('does_not_exist')).toBeNull();
+        await flagsmith.flushEvents();
+        expect(eventCalls(mockFetch)).toHaveLength(0);
+    });
+
+    test('repeated calls collapse to a single exposure within the window', async () => {
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: testIdentity }));
+        await flagsmith.init(initConfig);
+
+        flagsmith.getExperimentFlag('font_size');
+        flagsmith.getExperimentFlag('font_size');
+        flagsmith.getExperimentFlag('font_size');
+
+        await flagsmith.flushEvents();
+        const events = JSON.parse(eventCalls(mockFetch)[0][1].body).events;
+        expect(events.filter((e: any) => e.event === FLAG_EXPOSURE_EVENT)).toHaveLength(1);
+    });
+});

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -16,17 +16,22 @@ function eventCalls(mockFetch: jest.Mock) {
 }
 
 describe('events gate', () => {
-    test('trackEvent throws when events are not enabled', async () => {
-        const { flagsmith, initConfig } = getFlagsmith();
+    test('trackEvent is a no-op when events are not enabled', async () => {
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith();
         await flagsmith.init(initConfig);
-        expect(() => flagsmith.trackEvent('purchase')).toThrow(/events must be enabled/i);
+        expect(() => flagsmith.trackEvent('purchase')).not.toThrow();
+        await flagsmith.flushEvents();
+        expect(eventCalls(mockFetch)).toHaveLength(0);
     });
 
-    test('trackExposureEvent and getExperimentFlag throw when not enabled', async () => {
-        const { flagsmith, initConfig } = getFlagsmith();
+    test('trackExposureEvent and getExperimentFlag are no-ops when not enabled', async () => {
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith({ identity: testIdentity });
         await flagsmith.init(initConfig);
-        expect(() => flagsmith.trackExposureEvent('f')).toThrow(/events must be enabled/i);
-        expect(() => flagsmith.getExperimentFlag('f')).toThrow(/events must be enabled/i);
+        expect(() => flagsmith.trackExposureEvent('font_size')).not.toThrow();
+        // getExperimentFlag still returns the flag, just records no exposure.
+        expect(flagsmith.getExperimentFlag('font_size')).toEqual(expect.objectContaining({ value: 16 }));
+        await flagsmith.flushEvents();
+        expect(eventCalls(mockFetch)).toHaveLength(0);
     });
 
     test('eventProcessorConfig without enableEvents throws at init', async () => {

--- a/test/react-events.test.tsx
+++ b/test/react-events.test.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from 'react'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { FlagsmithProvider, useExperiment } from '../react'
-import { getFlagsmith, testIdentity, getMockFetchWithValue } from './test-constants'
+import { getFlagsmith, testIdentity, experimentIdentity, getMockFetchWithValue } from './test-constants'
 
 const eventsUrl = 'https://events.test/'
 
@@ -30,7 +30,7 @@ const Probe: FC<{ feature: string }> = ({ feature }) => {
 
 describe('useExperiment', () => {
     test('fires one $flag_exposure when identified and source is SERVER', async () => {
-        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: testIdentity }))
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: experimentIdentity }))
         render(
             <FlagsmithProvider flagsmith={flagsmith} options={initConfig}>
                 <Probe feature="font_size" />
@@ -48,13 +48,13 @@ describe('useExperiment', () => {
         expect(fired).toHaveLength(1)
         expect(fired[0]).toEqual(expect.objectContaining({
             feature_name: 'font_size',
-            identifier: testIdentity,
-            value: '16',
+            identifier: experimentIdentity,
+            value: 'control',
         }))
     })
 
     test('repeated parent re-renders produce only one exposure', async () => {
-        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: testIdentity }))
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: experimentIdentity }))
 
         const Storm: FC = () => {
             const [n, setN] = useState(0)
@@ -86,8 +86,8 @@ describe('useExperiment', () => {
         expect(exposures(mockFetch)).toHaveLength(1)
     })
 
-    test('a variant value change fires a second exposure', async () => {
-        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: testIdentity }))
+    test('a variant change fires a second exposure even when the value is unchanged', async () => {
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: experimentIdentity }))
         render(
             <FlagsmithProvider flagsmith={flagsmith} options={initConfig}>
                 <Probe feature="font_size" />
@@ -98,26 +98,26 @@ describe('useExperiment', () => {
             expect(JSON.parse(screen.getByTestId('exp').innerHTML)?.value).toBe(16)
         })
 
-        // Next fetch returns font_size = 20 for the identified user.
+        // Next fetch buckets the user into a different variant with the same value.
         getMockFetchWithValue(mockFetch, {
             flags: [
-                { enabled: true, feature_state_value: 20, feature: { id: 6149, name: 'font_size' } },
+                { enabled: true, feature_state_value: 16, variant: 'large', feature: { id: 6149, name: 'font_size' } },
             ],
             traits: [],
         })
         await flagsmith.getFlags()
 
         await waitFor(() => {
-            expect(JSON.parse(screen.getByTestId('exp').innerHTML)?.value).toBe(20)
+            expect(JSON.parse(screen.getByTestId('exp').innerHTML)?.variant).toBe('large')
         })
 
         await flagsmith.flushEvents()
         const values = exposures(mockFetch).map((e: any) => e.value)
-        expect(values).toEqual(['16', '20'])
+        expect(values).toEqual(['control', 'large'])
     })
 
     test('fires a fresh exposure when identity changes even if the value is unchanged', async () => {
-        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: testIdentity }))
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: experimentIdentity }))
         render(
             <FlagsmithProvider flagsmith={flagsmith} options={initConfig}>
                 <Probe feature="font_size" />
@@ -128,10 +128,10 @@ describe('useExperiment', () => {
             expect(JSON.parse(screen.getByTestId('exp').innerHTML)?.value).toBe(16)
         })
 
-        // A different identity that resolves the SAME font_size value (16).
+        // A different identity that resolves the SAME font_size variant and value.
         getMockFetchWithValue(mockFetch, {
             flags: [
-                { enabled: true, feature_state_value: 16, feature: { id: 6149, name: 'font_size' } },
+                { enabled: true, feature_state_value: 16, variant: 'control', feature: { id: 6149, name: 'font_size' } },
             ],
             traits: [],
         })
@@ -141,7 +141,7 @@ describe('useExperiment', () => {
             await flagsmith.flushEvents()
             expect(exposures(mockFetch)).toHaveLength(2)
         })
-        expect(exposures(mockFetch).map((e: any) => e.identifier)).toEqual([testIdentity, 'other_identity'])
+        expect(exposures(mockFetch).map((e: any) => e.identifier)).toEqual([experimentIdentity, 'other_identity'])
     })
 
     test('renders the flag but fires no exposure when events are disabled', async () => {

--- a/test/react-events.test.tsx
+++ b/test/react-events.test.tsx
@@ -116,6 +116,34 @@ describe('useExperiment', () => {
         expect(values).toEqual(['16', '20'])
     })
 
+    test('fires a fresh exposure when identity changes even if the value is unchanged', async () => {
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: testIdentity }))
+        render(
+            <FlagsmithProvider flagsmith={flagsmith} options={initConfig}>
+                <Probe feature="font_size" />
+            </FlagsmithProvider>
+        )
+
+        await waitFor(() => {
+            expect(JSON.parse(screen.getByTestId('exp').innerHTML)?.value).toBe(16)
+        })
+
+        // A different identity that resolves the SAME font_size value (16).
+        getMockFetchWithValue(mockFetch, {
+            flags: [
+                { enabled: true, feature_state_value: 16, feature: { id: 6149, name: 'font_size' } },
+            ],
+            traits: [],
+        })
+        await flagsmith.identify('other_identity')
+
+        await waitFor(async () => {
+            await flagsmith.flushEvents()
+            expect(exposures(mockFetch)).toHaveLength(2)
+        })
+        expect(exposures(mockFetch).map((e: any) => e.identifier)).toEqual([testIdentity, 'other_identity'])
+    })
+
     test('renders the flag but fires no exposure when events are disabled', async () => {
         const { flagsmith, initConfig, mockFetch } = getFlagsmith({ identity: testIdentity })
         render(

--- a/test/react-events.test.tsx
+++ b/test/react-events.test.tsx
@@ -1,0 +1,166 @@
+import React, { FC, useState } from 'react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { FlagsmithProvider, useExperiment } from '../react'
+import { getFlagsmith, testIdentity, getMockFetchWithValue } from './test-constants'
+
+const eventsUrl = 'https://events.test/'
+
+function eventsConfig(extra: any = {}) {
+    return {
+        enableEvents: true,
+        eventProcessorConfig: { eventsApiUrl: eventsUrl, flushInterval: 60000 },
+        ...extra,
+    }
+}
+
+function eventCalls(mockFetch: jest.Mock) {
+    return mockFetch.mock.calls.filter(([url]: [string]) => url.includes('/v1/events'))
+}
+
+function exposures(mockFetch: jest.Mock) {
+    return eventCalls(mockFetch).flatMap(([, opts]: [string, any]) =>
+        JSON.parse(opts.body).events.filter((e: any) => e.event === '$flag_exposure')
+    )
+}
+
+const Probe: FC<{ feature: string }> = ({ feature }) => {
+    const flag = useExperiment(feature)
+    return <div data-testid="exp">{JSON.stringify(flag)}</div>
+}
+
+describe('useExperiment', () => {
+    test('fires one $flag_exposure when identified and source is SERVER', async () => {
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: testIdentity }))
+        render(
+            <FlagsmithProvider flagsmith={flagsmith} options={initConfig}>
+                <Probe feature="font_size" />
+            </FlagsmithProvider>
+        )
+
+        await waitFor(() => {
+            expect(JSON.parse(screen.getByTestId('exp').innerHTML)).toEqual(
+                expect.objectContaining({ enabled: true, value: 16 })
+            )
+        })
+
+        await flagsmith.flushEvents()
+        const fired = exposures(mockFetch)
+        expect(fired).toHaveLength(1)
+        expect(fired[0]).toEqual(expect.objectContaining({
+            feature_name: 'font_size',
+            identifier: testIdentity,
+            value: '16',
+        }))
+    })
+
+    test('repeated parent re-renders produce only one exposure', async () => {
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: testIdentity }))
+
+        const Storm: FC = () => {
+            const [n, setN] = useState(0)
+            return (
+                <>
+                    <button data-testid="bump" onClick={() => setN((x) => x + 1)}>bump</button>
+                    <Probe feature="font_size" />
+                    <span data-testid="n">{n}</span>
+                </>
+            )
+        }
+
+        render(
+            <FlagsmithProvider flagsmith={flagsmith} options={initConfig}>
+                <Storm />
+            </FlagsmithProvider>
+        )
+
+        await waitFor(() => {
+            expect(JSON.parse(screen.getByTestId('exp').innerHTML)?.value).toBe(16)
+        })
+
+        for (let i = 0; i < 5; i++) {
+            fireEvent.click(screen.getByTestId('bump'))
+        }
+        await waitFor(() => expect(screen.getByTestId('n').innerHTML).toBe('5'))
+
+        await flagsmith.flushEvents()
+        expect(exposures(mockFetch)).toHaveLength(1)
+    })
+
+    test('a variant value change fires a second exposure', async () => {
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: testIdentity }))
+        render(
+            <FlagsmithProvider flagsmith={flagsmith} options={initConfig}>
+                <Probe feature="font_size" />
+            </FlagsmithProvider>
+        )
+
+        await waitFor(() => {
+            expect(JSON.parse(screen.getByTestId('exp').innerHTML)?.value).toBe(16)
+        })
+
+        // Next fetch returns font_size = 20 for the identified user.
+        getMockFetchWithValue(mockFetch, {
+            flags: [
+                { enabled: true, feature_state_value: 20, feature: { id: 6149, name: 'font_size' } },
+            ],
+            traits: [],
+        })
+        await flagsmith.getFlags()
+
+        await waitFor(() => {
+            expect(JSON.parse(screen.getByTestId('exp').innerHTML)?.value).toBe(20)
+        })
+
+        await flagsmith.flushEvents()
+        const values = exposures(mockFetch).map((e: any) => e.value)
+        expect(values).toEqual(['16', '20'])
+    })
+
+    test('renders the flag but fires no exposure when events are disabled', async () => {
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith({ identity: testIdentity })
+        render(
+            <FlagsmithProvider flagsmith={flagsmith} options={initConfig}>
+                <Probe feature="font_size" />
+            </FlagsmithProvider>
+        )
+
+        await waitFor(() => {
+            expect(JSON.parse(screen.getByTestId('exp').innerHTML)?.value).toBe(16)
+        })
+
+        await flagsmith.flushEvents()
+        expect(eventCalls(mockFetch)).toHaveLength(0)
+    })
+
+    test('fires no exposure when there is no identity, still renders the flag', async () => {
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig())
+        render(
+            <FlagsmithProvider flagsmith={flagsmith} options={initConfig}>
+                <Probe feature="font_size" />
+            </FlagsmithProvider>
+        )
+
+        await waitFor(() => {
+            expect(JSON.parse(screen.getByTestId('exp').innerHTML)?.value).toBe(16)
+        })
+
+        await flagsmith.flushEvents()
+        expect(eventCalls(mockFetch)).toHaveLength(0)
+    })
+
+    test('returns null and fires no exposure for an absent feature', async () => {
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: testIdentity }))
+        render(
+            <FlagsmithProvider flagsmith={flagsmith} options={initConfig}>
+                <Probe feature="does_not_exist" />
+            </FlagsmithProvider>
+        )
+
+        await waitFor(() => {
+            expect(screen.getByTestId('exp').innerHTML).toBe('null')
+        })
+
+        await flagsmith.flushEvents()
+        expect(eventCalls(mockFetch)).toHaveLength(0)
+    })
+})

--- a/test/react-variant.test.tsx
+++ b/test/react-variant.test.tsx
@@ -1,0 +1,51 @@
+import React, { FC } from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { FlagsmithProvider, useFlags } from '../react'
+import { getFlagsmith, experimentIdentity, getMockFetchWithValue } from './test-constants'
+
+const FlagsPage: FC<{ flags: string[] }> = ({ flags: names }) => {
+    const flags = useFlags(names)
+    return <div data-testid="flags">{JSON.stringify(flags)}</div>
+}
+
+const renderedFlags = () => JSON.parse(screen.getByTestId('flags').innerHTML)
+
+describe('useFlags variant', () => {
+    test('re-renders when only the variant changes', async () => {
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith({ identity: experimentIdentity })
+        render(
+            <FlagsmithProvider flagsmith={flagsmith} options={initConfig}>
+                <FlagsPage flags={['font_size']} />
+            </FlagsmithProvider>
+        )
+
+        await waitFor(() => {
+            expect(renderedFlags().font_size).toEqual({ enabled: true, value: 16, variant: 'control' })
+        })
+
+        getMockFetchWithValue(mockFetch, {
+            flags: [
+                { enabled: true, feature_state_value: 16, variant: 'large', feature: { id: 6149, name: 'font_size' } },
+            ],
+            traits: [],
+        })
+        await flagsmith.getFlags()
+
+        await waitFor(() => {
+            expect(renderedFlags().font_size.variant).toBe('large')
+        })
+    })
+
+    test('surfaces the variant when the flag name needs normalising', async () => {
+        const { flagsmith, initConfig } = getFlagsmith({ identity: experimentIdentity })
+        render(
+            <FlagsmithProvider flagsmith={flagsmith} options={initConfig}>
+                <FlagsPage flags={['Font Size']} />
+            </FlagsmithProvider>
+        )
+
+        await waitFor(() => {
+            expect(renderedFlags()['Font Size']).toEqual({ enabled: true, value: 16, variant: 'control' })
+        })
+    })
+})

--- a/test/resolve-trait-values.test.ts
+++ b/test/resolve-trait-values.test.ts
@@ -1,0 +1,28 @@
+import { resolveTraitValues } from '../utils/types';
+
+describe('resolveTraitValues', () => {
+    test('resolves envelope traits to plain key/value', () => {
+        const result = resolveTraitValues({
+            plan: { value: 'premium' },
+            age: { value: 42, transient: true },
+        });
+        expect(result).toEqual({ plan: 'premium', age: 42 });
+    });
+
+    test('passes through already-plain values', () => {
+        expect(resolveTraitValues({ plan: 'premium' } as any)).toEqual({ plan: 'premium' });
+    });
+
+    test('returns null for empty object', () => {
+        expect(resolveTraitValues({})).toBeNull();
+    });
+
+    test('returns null for null/undefined', () => {
+        expect(resolveTraitValues(null)).toBeNull();
+        expect(resolveTraitValues(undefined)).toBeNull();
+    });
+
+    test('drops null trait entries', () => {
+        expect(resolveTraitValues({ a: { value: 1 }, b: null })).toEqual({ a: 1 });
+    });
+});

--- a/test/test-constants.ts
+++ b/test/test-constants.ts
@@ -1,6 +1,6 @@
-import { IInitConfig, IState } from '../lib/flagsmith/types';
+import { IInitConfig, IState } from '../types';
 import MockAsyncStorage from './mocks/async-storage-mock';
-import { createFlagsmithInstance } from '../lib/flagsmith';
+import { createFlagsmithInstance } from '../index';
 import Mock = jest.Mock;
 import { promises as fs } from 'fs';
 
@@ -76,6 +76,12 @@ export function getFlagsmith(config: Partial<IInitConfig> = {}) {
     const flagsmith = createFlagsmithInstance();
     const AsyncStorage = new MockAsyncStorage();
     const mockFetch = jest.fn(async (url, options) => {
+        if (url.includes('/v1/events')) {
+            return {status: 202, text: () => Promise.resolve('')}
+        }
+        if (url.includes('analytics/flags')) {
+            return {status: 200, text: () => Promise.resolve('{}')}
+        }
         switch (url) {
             case 'https://edge.api.flagsmith.com/api/v1/flags/':
                 return {status: 200, text: () => fs.readFile('./test/data/flags.json', 'utf8')}

--- a/test/test-constants.ts
+++ b/test/test-constants.ts
@@ -25,6 +25,7 @@ export const defaultState = {
 };
 
 export const testIdentity = 'test_identity'
+export const experimentIdentity = 'test_experiment_identity'
 export const identityState = {
     api: 'https://edge.api.flagsmith.com/api/v1/',
     identity: testIdentity,
@@ -87,6 +88,8 @@ export function getFlagsmith(config: Partial<IInitConfig> = {}) {
                 return {status: 200, text: () => fs.readFile('./test/data/flags.json', 'utf8')}
             case 'https://edge.api.flagsmith.com/api/v1/identities/?identifier=' + testIdentity:
                 return {status: 200, text: () => fs.readFile(`./test/data/identities_${testIdentity}.json`, 'utf8')}
+            case 'https://edge.api.flagsmith.com/api/v1/identities/?identifier=' + experimentIdentity:
+                return {status: 200, text: () => fs.readFile(`./test/data/identities_${experimentIdentity}.json`, 'utf8')}
         }
 
         throw new Error('Please mock the call to ' + url)

--- a/test/variant.test.ts
+++ b/test/variant.test.ts
@@ -1,0 +1,120 @@
+import { getFlagsmith, testIdentity } from './test-constants';
+import { FLAG_EXPOSURE_EVENT } from '../event-processor';
+
+const eventsUrl = 'https://events.test/';
+
+// Identity payload where one flag carries a multivariate `variant` key, one is
+// in the control bucket, and one is a plain (non-variant) flag.
+const identityWithVariant = {
+    identifier: testIdentity,
+    traits: [],
+    flags: [
+        {
+            feature: { id: 1, name: 'experiment', type: 'MULTIVARIATE' },
+            enabled: true,
+            feature_state_value: 'variant_value',
+            variant: 'variant_a',
+        },
+        {
+            feature: { id: 2, name: 'control_experiment', type: 'MULTIVARIATE' },
+            enabled: true,
+            feature_state_value: 'control_value',
+            variant: 'control',
+        },
+        {
+            feature: { id: 3, name: 'font_size', type: 'STANDARD' },
+            enabled: true,
+            feature_state_value: 16,
+        },
+        {
+            feature: { id: 4, name: 'empty_variant', type: 'MULTIVARIATE' },
+            enabled: true,
+            feature_state_value: 'value',
+            variant: '',
+        },
+        {
+            feature: { id: 5, name: 'empty_value_experiment', type: 'MULTIVARIATE' },
+            enabled: true,
+            feature_state_value: '',
+            variant: 'variant_b',
+        },
+    ],
+};
+
+async function initWithVariants() {
+    const { flagsmith, initConfig, mockFetch } = getFlagsmith({
+        enableEvents: true,
+        eventProcessorConfig: { eventsApiUrl: eventsUrl, flushInterval: 60000 },
+        identity: testIdentity,
+    });
+    // Replace the identity endpoint response with one that carries variant keys.
+    mockFetch.mockImplementation(async (url: string) => {
+        if (url.includes('/v1/events')) {
+            return { status: 202, text: () => Promise.resolve('') };
+        }
+        if (url.includes('analytics/flags')) {
+            return { status: 200, text: () => Promise.resolve('{}') };
+        }
+        if (url.includes('/identities/')) {
+            return { status: 200, text: () => Promise.resolve(JSON.stringify(identityWithVariant)) };
+        }
+        throw new Error('Please mock the call to ' + url);
+    });
+    await flagsmith.init(initConfig);
+    return { flagsmith, mockFetch };
+}
+
+describe('variant key', () => {
+    test('surfaces the variant key, "control" bucket, and omits it for plain flags', async () => {
+        const { flagsmith } = await initWithVariants();
+        const flags = flagsmith.getAllFlags();
+        expect(flags.experiment).toEqual(
+            expect.objectContaining({ enabled: true, value: 'variant_value', variant: 'variant_a' })
+        );
+        expect(flags.control_experiment.variant).toBe('control');
+        expect(flags.font_size.variant).toBeUndefined();
+    });
+
+    test('getExperimentFlag uses the variant as the exposure value and skips flags without one', async () => {
+        const { flagsmith, mockFetch } = await initWithVariants();
+
+        flagsmith.getExperimentFlag('experiment');
+        flagsmith.getExperimentFlag('control_experiment');
+        flagsmith.getExperimentFlag('font_size');
+        await flagsmith.flushEvents();
+
+        const [, opts] = mockFetch.mock.calls.find(([url]) => url.includes('/v1/events'))!;
+        const exposures = JSON.parse(opts.body).events.filter((e: any) => e.event === FLAG_EXPOSURE_EVENT);
+        expect(exposures).toEqual([
+            expect.objectContaining({ feature_name: 'experiment', value: 'variant_a' }),
+            expect.objectContaining({ feature_name: 'control_experiment', value: 'control' }),
+        ]);
+    });
+
+    test('treats an empty-string variant as absent and records no exposure for it', async () => {
+        const { flagsmith, mockFetch } = await initWithVariants();
+
+        expect(flagsmith.getAllFlags().empty_variant.variant).toBeUndefined();
+
+        flagsmith.getExperimentFlag('empty_variant');
+        await flagsmith.flushEvents();
+        expect(mockFetch.mock.calls.find(([url]) => url.includes('/v1/events'))).toBeUndefined();
+    });
+
+    test('surfaces the variant and records an exposure when the flag value is an empty string', async () => {
+        const { flagsmith, mockFetch } = await initWithVariants();
+
+        expect(flagsmith.getAllFlags().empty_value_experiment).toEqual(
+            expect.objectContaining({ enabled: true, value: '', variant: 'variant_b' })
+        );
+
+        flagsmith.getExperimentFlag('empty_value_experiment');
+        await flagsmith.flushEvents();
+
+        const [, opts] = mockFetch.mock.calls.find(([url]) => url.includes('/v1/events'))!;
+        const exposures = JSON.parse(opts.body).events.filter((e: any) => e.event === FLAG_EXPOSURE_EVENT);
+        expect(exposures).toEqual([
+            expect.objectContaining({ feature_name: 'empty_value_experiment', value: 'variant_b' }),
+        ]);
+    });
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -291,8 +291,8 @@ T extends string = string
      */
     setTraits: (traits: ITraits) => Promise<void>;
     /**
-     * Record an arbitrary product event (e.g. "purchase"). Requires
-     * enableEvents: true (throws otherwise). identifier/traits default to the
+     * Record an arbitrary product event (e.g. "purchase"). No-op when events
+     * are disabled (enableEvents is not set). identifier/traits default to the
      * current identified context when omitted.
      * @experimental @internal
      */
@@ -304,7 +304,8 @@ T extends string = string
     }) => void;
     /**
      * Record that an identity was exposed to a flag/variant (emits the reserved
-     * "$flag_exposure" event). Requires enableEvents: true (throws otherwise).
+     * "$flag_exposure" event). No-op when events are disabled (enableEvents is
+     * not set).
      * @experimental @internal
      */
     trackExposureEvent: (featureName: string, opts?: {
@@ -316,7 +317,8 @@ T extends string = string
     /**
      * Resolve a flag for the currently identified user and fire one
      * "$flag_exposure" event (skipped unless flags were loaded from the server
-     * and the feature exists). Requires enableEvents: true (throws otherwise).
+     * and the feature exists). When events are disabled (enableEvents is not
+     * set) this degrades to a plain flag read.
      * @experimental @internal
      */
     getExperimentFlag: (featureName: string) => IFlagsmithFeature | null;

--- a/types.d.ts
+++ b/types.d.ts
@@ -131,7 +131,26 @@ export interface IInitConfig<F extends string | Record<string, any> = string, T 
      * Customer application metadata
      */
     applicationMetadata?: ApplicationMetadata;
+    /**
+     * @experimental Internal use only — API may change without notice.
+     * Opt-in gate for the events pipeline. When true, an EventProcessor is
+     * started and trackEvent / trackExposureEvent / getExperimentFlag become
+     * available.
+     * @internal
+     */
+    enableEvents?: boolean;
+    /**
+     * @experimental Optional tuning for the events pipeline. Only valid when
+     * enableEvents is true (passing it without enableEvents throws at init).
+     * @internal
+     */
+    eventProcessorConfig?: {
+        eventsApiUrl?: string;
+        maxBuffer?: number;
+        flushInterval?: number;
+    };
 }
+
 
 export interface IFlagsmithResponse {
     identifier?: string,
@@ -271,6 +290,42 @@ T extends string = string
      * Set a key value set of traits for a given user, triggers a call to get flags
      */
     setTraits: (traits: ITraits) => Promise<void>;
+    /**
+     * Record an arbitrary product event (e.g. "purchase"). Requires
+     * enableEvents: true (throws otherwise). identifier/traits default to the
+     * current identified context when omitted.
+     * @experimental @internal
+     */
+    trackEvent: (event: string, opts?: {
+        identifier?: string | null;
+        value?: string | number | boolean | null;
+        traits?: ITraits;
+        metadata?: Record<string, unknown>;
+    }) => void;
+    /**
+     * Record that an identity was exposed to a flag/variant (emits the reserved
+     * "$flag_exposure" event). Requires enableEvents: true (throws otherwise).
+     * @experimental @internal
+     */
+    trackExposureEvent: (featureName: string, opts?: {
+        identifier?: string | null;
+        value?: string | number | boolean | null;
+        traits?: ITraits;
+        metadata?: Record<string, unknown>;
+    }) => void;
+    /**
+     * Resolve a flag for the currently identified user and fire one
+     * "$flag_exposure" event (skipped unless flags were loaded from the server
+     * and the feature exists). Requires enableEvents: true (throws otherwise).
+     * @experimental @internal
+     */
+    getExperimentFlag: (featureName: string) => IFlagsmithFeature | null;
+    /**
+     * Force-flush any buffered events. Useful server-side/SSR where the timer
+     * may not fire before the request ends. No-op when events are disabled.
+     * @experimental @internal
+     */
+    flushEvents: () => Promise<void>;
     /**
      * The stored identity of the user
     */

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,7 +1,7 @@
 import { EvaluationContext, IdentityEvaluationContext, TraitEvaluationContext } from "./evaluation-context";
 import { FlagSource } from "./flagsmith-core";
 
-type IFlagsmithValue<T = string | number | boolean | null> = T
+export type IFlagsmithValue<T = string | number | boolean | null> = T
 
 export type DynatraceObject = {
     "javaLongOrObject": Record<string, number>,
@@ -298,7 +298,7 @@ T extends string = string
      */
     trackEvent: (event: string, opts?: {
         identifier?: string | null;
-        value?: string | number | boolean | null;
+        value?: IFlagsmithValue;
         traits?: ITraits;
         metadata?: Record<string, unknown>;
     }) => void;
@@ -309,7 +309,7 @@ T extends string = string
      */
     trackExposureEvent: (featureName: string, opts?: {
         identifier?: string | null;
-        value?: string | number | boolean | null;
+        value?: IFlagsmithValue;
         traits?: ITraits;
         metadata?: Record<string, unknown>;
     }) => void;

--- a/types.d.ts
+++ b/types.d.ts
@@ -327,6 +327,13 @@ T extends string = string
      */
     flushEvents: () => Promise<void>;
     /**
+     * Whether the events pipeline is enabled (enableEvents: true was passed
+     * to init). Used by the React useExperiment hook to skip exposure
+     * recording when events are off.
+     * @experimental @internal
+     */
+    readonly eventsEnabled: boolean;
+    /**
      * The stored identity of the user
     */
     identity?: IIdentity;

--- a/types.d.ts
+++ b/types.d.ts
@@ -14,6 +14,7 @@ export interface IFlagsmithFeature<Value = IFlagsmithValue> {
     id?: number;
     enabled: boolean;
     value: Value;
+    variant?: string;
 }
 
 export declare type IFlagsmithTrait = IFlagsmithValue | TraitEvaluationContext;
@@ -162,6 +163,7 @@ export interface IFlagsmithResponse {
     flags?: {
         enabled: boolean;
         feature_state_value: IFlagsmithValue;
+        variant?: string;
         feature: {
             id: number;
             name: string;
@@ -316,9 +318,10 @@ T extends string = string
     }) => void;
     /**
      * Resolve a flag for the currently identified user and fire one
-     * "$flag_exposure" event (skipped unless flags were loaded from the server
-     * and the feature exists). When events are disabled (enableEvents is not
-     * set) this degrades to a plain flag read.
+     * "$flag_exposure" event with the selected variant as its value (skipped
+     * unless flags were loaded from the server and the flag has a variant).
+     * When events are disabled (enableEvents is not set) this degrades to a
+     * plain flag read.
      * @experimental @internal
      */
     getExperimentFlag: (featureName: string) => IFlagsmithFeature | null;

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -22,3 +22,14 @@ export function toEvaluationContext(clientEvaluationContext: ClientEvaluationCon
         } : undefined,
     }
 }
+
+export function resolveTraitValues(
+    traits?: { [key: string]: TraitEvaluationContext | IFlagsmithTrait | null } | null
+): Record<string, any> | null {
+    if (!traits) return null;
+    const entries = Object.entries(traits).filter(([, v]) => v !== null && v !== undefined);
+    if (!entries.length) return null;
+    return Object.fromEntries(
+        entries.map(([k, v]) => [k, isTraitEvaluationContext(v) ? v.value : v])
+    );
+}

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -1,5 +1,5 @@
 import { EvaluationContext, TraitEvaluationContext } from "../evaluation-context";
-import { ClientEvaluationContext, ITraits, IFlagsmithTrait } from "../types";
+import { ClientEvaluationContext, ITraits, IFlagsmithTrait, IFlagsmithValue } from "../types";
 
 export function isTraitEvaluationContext(trait: TraitEvaluationContext | IFlagsmithTrait): trait is TraitEvaluationContext {
     return !!trait && typeof trait == 'object' && trait.value !== undefined;
@@ -25,7 +25,7 @@ export function toEvaluationContext(clientEvaluationContext: ClientEvaluationCon
 
 export function resolveTraitValues(
     traits?: { [key: string]: TraitEvaluationContext | IFlagsmithTrait | null } | null
-): Record<string, any> | null {
+): Record<string, IFlagsmithValue> | null {
     if (!traits) return null;
     const entries = Object.entries(traits).filter(([, v]) => v !== null && v !== undefined);
     if (!entries.length) return null;


### PR DESCRIPTION
- [x] I have read the Contributing Guide.
- [ ] I have added information to `docs/` if required.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Contributes to Flagsmith/flagsmith-analytics-pipeline#9

Adds an experimentation events surface to the JS client.

- ⚠️ Experimental/internal: the whole surface is marked `@experimental @internal` and may change without notice.
- Opt-in via `enableEvents: true` + optional `eventProcessorConfig`; the methods no-op when not enabled (getExperimentFlag degrades to a plain flag read), so call sites never need to gate on enableEvents.
- Public API: `trackEvent`, `trackExposureEvent` (emits `$flag_exposure`), `getExperimentFlag`, `flushEvents` (SSR/teardown).
- New `EventProcessor` module: buffers events, flushes on timer/full/`stop()`, `POST {url}/v1/events` with `X-Environment-Key` + `flagsmith-js-sdk` UA, retry-once-then-drop (failed batches never re-enter the buffer). `value` stringified at buffer time.
- JS-specific: sync identifier-less `getExperimentFlag` reading the ambient identity; exposure de-dup per flush window; skip the exposure and log a message on each call when no identity is set (anonymous experiments require an explicit `identify(..., transient: true)`).

### React / React Native

Adds a `useExperiment` React hook so experiments work idiomatically in component trees. React Native consumes the same `react.tsx` source at build time, so the hook ships to both packages with no RN-specific code.

- `useExperiment(featureName): IFlagsmithFeature | null` — reads the flag purely for render (`getAllFlags()`), and records one `$flag_exposure` as a side-effect.
- Re-renders when the flag's value/enabled changes (subscribes to the internal change emitter with `events.on(...)` + effect cleanup — leak-free, unlike the older `once`-in-`useRef` pattern).
- Safe against re-render storms: the exposure fires only from a dependency-gated effect, further guarded by a `useRef` last-fired key (one exposure per distinct `(feature, identifier, value)` per mount), with the core flush-window dedup underneath. Frequent re-renders never amplify into events.
- Degrades gracefully when events are disabled — returns the flag, never throws, records nothing.
- Supporting core change: a public read-only `eventsEnabled` boolean on the instance, so the hook can skip the (throwing) `getExperimentFlag` when events are off without using exceptions for control flow.

## How did you test this code?

- `npm test` — full suite green, with new coverage added for this feature:
  - `event-processor.test.ts`: buffering/wire shape, exposure-only dedupe, flush + headers, timer lifecycle, flush-on-stop, retry-once-then-drop.
  - `events.test.ts`: enablement gate, `trackEvent` shape + context defaulting, reserved `$`-prefix rejection, `getExperimentFlag` (fires when identified, skips/warns with no identity, skips for default/absent flags, dedupes repeats), and `eventsEnabled` reflecting config.
  - `react-events.test.tsx`: `useExperiment` fires one exposure when identified + SERVER, only one exposure across repeated re-renders, a second exposure on variant-value change, graceful no-op when events disabled / no identity, and `null` for an absent feature.
  - `resolve-trait-values.test.ts`: envelope → plain resolution.


