### PR TITLE
feat: skip exposure event for disabled flags in getExperimentFlag

### DIFF
--- a/flagsmith-core.ts
+++ b/flagsmith-core.ts
@@ -1001,6 +1001,10 @@ const Flagsmith = class {
             this.log(`Flagsmith: getExperimentFlag called for "${featureName}" which does not exist. No exposure recorded.`);
             return null;
         }
+        if (!flag.enabled) {
+            this.log(`Flagsmith: getExperimentFlag called for "${featureName}" which is disabled. No exposure recorded.`);
+            return flag;
+        }
         if (!flag.variant) {
             this.log(`Flagsmith: getExperimentFlag called for "${featureName}" which has no variant; experiments require a multivariate flag. No exposure recorded.`);
             return flag;

--- a/test/data/identities_test_experiment_identity.json
+++ b/test/data/identities_test_experiment_identity.json
@@ -19,6 +19,16 @@
             "enabled": true,
             "feature_state_value": 16,
             "variant": "control"
+        },
+        {
+            "feature": {
+                "id": 80321,
+                "name": "disabled_experiment",
+                "type": "MULTIVARIATE"
+            },
+            "enabled": false,
+            "feature_state_value": null,
+            "variant": "control"
         }
     ],
     "traits": []

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -144,6 +144,17 @@ describe('getExperimentFlag', () => {
         expect(eventCalls(mockFetch)).toHaveLength(0);
     });
 
+    test('skips exposure for a disabled flag even when it has a variant, still returns it', async () => {
+        const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: experimentIdentity }));
+        await flagsmith.init(initConfig); // identified, source SERVER
+
+        const flag = flagsmith.getExperimentFlag('disabled_experiment');
+        expect(flag).toEqual(expect.objectContaining({ enabled: false, variant: 'control' }));
+
+        await flagsmith.flushEvents();
+        expect(eventCalls(mockFetch)).toHaveLength(0);
+    });
+
     test('skips exposure and returns null for an absent feature', async () => {
         const { flagsmith, initConfig, mockFetch } = getFlagsmith(eventsConfig({ identity: testIdentity }));
         await flagsmith.init(initConfig);


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

`getExperimentFlag` no longer fires a `$flag_exposure` event when the resolved flag is disabled, keeping experimentation data clean. The flag is still returned unchanged — only the exposure event is skipped.

## How did you test this code?

Added a unit test in `test/events.test.ts` (disabled `off_value` fixture): asserts the flag is returned and no event is flushed. Full suite green.
